### PR TITLE
[ELK_NGINX] Fix 404 errors on the shell installation process

### DIFF
--- a/ELK_NGINX-json/README.md
+++ b/ELK_NGINX-json/README.md
@@ -37,10 +37,10 @@ Unfortunately, Github does not provide a convenient one-click option to download
 ```shell
 mkdir  nginx_json_ELK_Example
 cd nginx_json_ELK_Example
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx-json/nginx_json_logstash.conf
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx-json/nginx_json_kibana.json
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx-json/nginx_json_template.json
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx-json/nginx_json_logs
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX-json/nginx_json_logstash.conf
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX-json/nginx_json_kibana.json
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX-json/nginx_json_template.json
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX-json/nginx_json_logs
 ```
 
 ** The JSON formatted NGINX logs used in this example were created with the following `log_format` entry in the `nginx.config` file.

--- a/ELK_NGINX/README.md
+++ b/ELK_NGINX/README.md
@@ -42,10 +42,10 @@ log_format combined '$remote_addr - $remote_user [$time_local] '
 ```shell
 mkdir  nginx_ELK_Example
 cd nginx_ELK_Example
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx/nginx_logstash.conf
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx/nginx_template.json
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx/nginx_kibana.json
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginx/nginx_logs
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX/nginx_logstash.conf
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX/nginx_template.json
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX/nginx_kibana.json
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX/nginx_logs
 ```
 
 ### Run Example

--- a/ELK_NGINX_Plus-json/README.md
+++ b/ELK_NGINX_Plus-json/README.md
@@ -41,10 +41,10 @@ Unfortunately, Github does not provide a convenient one-click option to download
 ```
 mkdir nginxplus_json_ELK_Example
 cd nginxplus_json_ELK_Example
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginxplus_json/nginxplus_json_logstash.conf
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginxplus_json/nginxplus_json_kibana.json
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginxplus_json/nginxplus_json_template.json
-wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nginxplus_json/nginxplus_json_logs
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX_Plus-json/nginxplus_json_logstash.conf
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX_Plus-json/nginxplus_json_kibana.json
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX_Plus-json/nginxplus_json_template.json
+wget https://raw.githubusercontent.com/elastic/examples/master/ELK_NGINX_Plus-json/nginxplus_json_logs
 ```
 
 ** The JSON formatted logs used in this example were created using status API of NGINX Plus. Please refer to [Live activity monitoring with NGINX Plus](https://www.nginx.com/products/live-activity-monitoring/) for more information on how to use status API of NGINX Plus


### PR DESCRIPTION
Old urls (`ELK_nginx/nginx_logstash.conf`) are throwing 404 from Github as the folder name is uppercase.