### PR TITLE
Update invalid resource urls due to repo name change.

### DIFF
--- a/ElasticStack_nyc_traffic_accidents/README.md
+++ b/ElasticStack_nyc_traffic_accidents/README.md
@@ -50,9 +50,9 @@ Example has been tested in following versions:
 
   Unfortunately, Github does not provide a convenient one-click option to download entire contents of a subfolder in a repo. You can either (a) [download](https://github.com/elastic/examples/archive/master.zip) or [clone](https://github.com/elastic/examples.git) the entire examples repo and navigate to `elk_nyc_accidents` subfolder, or (b) individually download the above files. The code below makes option (b) a little easier:
   ```shell
-  wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nyc_traffic_accidents/nyc_collision_logstash.conf
-  wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nyc_traffic_accidents/nyc_collision_template.json
-  wget https://raw.githubusercontent.com/elastic/examples/master/ELK_nyc_traffic_accidents/nyc_collision_kibana.json
+  wget https://raw.githubusercontent.com/elastic/examples/master/ElasticStack_nyc_traffic_accidents/nyc_collision_logstash.conf
+  wget https://raw.githubusercontent.com/elastic/examples/master/ElasticStack_nyc_traffic_accidents/nyc_collision_template.json
+  wget https://raw.githubusercontent.com/elastic/examples/master/ElasticStack_nyc_traffic_accidents/nyc_collision_kibana.json
   ```
 
 ### Run Example


### PR DESCRIPTION
Change `ELK_nyc_traffic_accidents` to `ElasticStack_nyc_traffic_accidents`.
