### PR TITLE
Update nginx_json_template.json

### DIFF
--- a/ElasticStack_NGINX-json/nginx_json_template.json
+++ b/ElasticStack_NGINX-json/nginx_json_template.json
@@ -10,7 +10,7 @@
            {
               "message_field": {
                  "mapping": {
-                    "omit_norms": true,
+                    "norms": false,
                     "type": "text"
                  },
                  "match_mapping_type": "string",
@@ -21,7 +21,7 @@
               "string_fields": {
                  "mapping": {
                     "type": "text",
-                    "omit_norms": true,
+                    "norms": false,
                     "fields": {
                        "raw": {
                           "type":"keyword",


### PR DESCRIPTION
[omit_norms] is deprecated, please use [norms] instead with the opposite boolean value