### PR TITLE
Update nginxplus_json_template.json

### DIFF
--- a/ElasticStack_NGINX_Plus-json/nginxplus_json_template.json
+++ b/ElasticStack_NGINX_Plus-json/nginxplus_json_template.json
@@ -10,7 +10,7 @@
            {
               "message_field": {
                  "mapping": {
-                    "omit_norms": true,
+                    "norms": false,
                     "type": "text"
                  },
                  "match_mapping_type": "string",
@@ -20,7 +20,7 @@
            {
               "string_fields": {
                  "mapping": {
-                    "omit_norms": true,
+                    "norms": false,
                     "type": "text",
                     "fields": {
                        "raw": {


### PR DESCRIPTION
[omit_norms] is deprecated, please use [norms] instead with the opposite boolean value