### PR TITLE
set geoip.ip type to ip

### DIFF
--- a/ElasticStack_apache/apache_template.json
+++ b/ElasticStack_apache/apache_template.json
@@ -43,6 +43,12 @@
                  },
                  "ip": {
                    "type": "ip"
+                 },
+                 "continent_code": {
+                  "type": "keyword"
+                 },
+                 "country_name": {
+                   "type": "keyword"
                  }
               },
               "type": "object"

--- a/ElasticStack_apache/apache_template.json
+++ b/ElasticStack_apache/apache_template.json
@@ -40,6 +40,9 @@
               "properties": {
                  "location": {
                     "type": "geo_point"
+                 },
+                 "ip": {
+                   "type": "ip"
                  }
               },
               "type": "object"


### PR DESCRIPTION
By default the type would be string, and ip aggregations won't work on it.