### PR TITLE
Added link to extension for downloading folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ You have a few options to get started with the examples:
 
 - If you want to try them all, you can [download the entire repo ](https://github.com/elastic/examples/archive/master.zip). Or, if you are familiar with Git, you can [clone the repo](https://github.com/elastic/examples.git). Then, simply follow the instructions in the individual README of the examples you're interested in to get started.
 
-- If you are only interested in a specific example or two, you can download the contents of just those examples (instructions in the individual READMEs).
+- If you are only interested in a specific example or two, you can download the contents of just those examples (by following instructions in the individual READMEs or using this [extension] (https://github.com/charany1/GHSDD)).
 
 ### Contributing
 


### PR DESCRIPTION
I created this extension as a hack a while back when I wanted to download a sub-directory of a repository rather than entire repo , hope it might help people wanting to download only a particular example . Follow instruction in README of GHSDD to install it , should hardly take 2-3 minutes .