### PR TITLE
changed .raw elements in dashboard to .keyword

### DIFF
--- a/Common Data Formats/apache_logs/logstash/apache_kibana.json
+++ b/Common Data Formats/apache_logs/logstash/apache_kibana.json
@@ -60,11 +60,11 @@
     "_type": "visualization",
     "_source": {
       "title": "Traffic by Country & Device",
-      "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"split\",\"params\":{\"field\":\"geoip.country_name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"row\":false}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"useragent.device.raw\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"split\",\"params\":{\"field\":\"geoip.country_name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"row\":false}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"useragent.device.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
       "description": "",
       "version": 1,
       "kibanaSavedObjectMeta": {
-        "searchSourceJSON": "{\"index\":\"apache_elastic_example\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[{\"meta\":{\"index\":\"apache_elastic_example\",\"key\":\"useragent.device.raw\",\"value\":\"Other\",\"disabled\":false,\"negate\":true,\"apply\":true},\"query\":{\"match\":{\"useragent.device.raw\":{\"query\":\"Other\",\"type\":\"phrase\"}}}},{\"meta\":{\"index\":\"apache_elastic_example\",\"key\":\"useragent.device.raw\",\"value\":\"Spider\",\"disabled\":false,\"negate\":true,\"apply\":true},\"query\":{\"match\":{\"useragent.device.raw\":{\"query\":\"Spider\",\"type\":\"phrase\"}}}}]}"
+        "searchSourceJSON": "{\"index\":\"apache_elastic_example\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[{\"meta\":{\"index\":\"apache_elastic_example\",\"key\":\"useragent.device.keyword\",\"value\":\"Other\",\"disabled\":false,\"negate\":true,\"apply\":true},\"query\":{\"match\":{\"useragent.device.keyword\":{\"query\":\"Other\",\"type\":\"phrase\"}}}},{\"meta\":{\"index\":\"apache_elastic_example\",\"key\":\"useragent.device.keyword\",\"value\":\"Spider\",\"disabled\":false,\"negate\":true,\"apply\":true},\"query\":{\"match\":{\"useragent.device.keyword\":{\"query\":\"Spider\",\"type\":\"phrase\"}}}}]}"
       }
     }
   },
@@ -73,11 +73,11 @@
     "_type": "visualization",
     "_source": {
       "title": "Traffic by Country & OS",
-      "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"split\",\"params\":{\"field\":\"geoip.country_name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"row\":false}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"useragent.os.raw\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "visState": "{\"type\":\"pie\",\"params\":{\"shareYAxis\":true,\"addTooltip\":true,\"addLegend\":true,\"isDonut\":true},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"3\",\"type\":\"terms\",\"schema\":\"split\",\"params\":{\"field\":\"geoip.country_name\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\",\"row\":false}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"segment\",\"params\":{\"field\":\"useragent.os.keyword\",\"size\":5,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
       "description": "",
       "version": 1,
       "kibanaSavedObjectMeta": {
-        "searchSourceJSON": "{\"index\":\"apache_elastic_example\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[{\"meta\":{\"index\":\"apache_elastic_example\",\"key\":\"useragent.os.raw\",\"value\":\"Other\",\"disabled\":false,\"negate\":true,\"apply\":true},\"query\":{\"match\":{\"useragent.os.raw\":{\"query\":\"Other\",\"type\":\"phrase\"}}}}]}"
+        "searchSourceJSON": "{\"index\":\"apache_elastic_example\",\"query\":{\"query_string\":{\"query\":\"*\",\"analyze_wildcard\":true}},\"filter\":[{\"meta\":{\"index\":\"apache_elastic_example\",\"key\":\"useragent.os.keyword\",\"value\":\"Other\",\"disabled\":false,\"negate\":true,\"apply\":true},\"query\":{\"match\":{\"useragent.os.keyword\":{\"query\":\"Other\",\"type\":\"phrase\"}}}}]}"
       }
     }
   },
@@ -86,7 +86,7 @@
     "_type": "visualization",
     "_source": {
       "title": "Unique Visits by City",
-      "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"clientip.raw\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"geoip.city_name.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"cardinality\",\"schema\":\"metric\",\"params\":{\"field\":\"clientip.keyword\"}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"geoip.city_name.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
       "description": "",
       "version": 1,
       "kibanaSavedObjectMeta": {
@@ -99,7 +99,7 @@
     "_type": "visualization",
     "_source": {
       "title": "Total Hits by City",
-      "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"geoip.city_name.raw\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
+      "visState": "{\"type\":\"table\",\"params\":{\"perPage\":10,\"showPartialRows\":false,\"showMeticsAtAllLevels\":false},\"aggs\":[{\"id\":\"1\",\"type\":\"count\",\"schema\":\"metric\",\"params\":{}},{\"id\":\"2\",\"type\":\"terms\",\"schema\":\"bucket\",\"params\":{\"field\":\"geoip.city_name.keyword\",\"size\":10,\"order\":\"desc\",\"orderBy\":\"1\"}}],\"listeners\":{}}",
       "description": "",
       "version": 1,
       "kibanaSavedObjectMeta": {


### PR DESCRIPTION
@gingerwizard can you sanity check this?

With the current version of kibana this wasn't working, since the element names switched from .raw to .keyword

I will try to get the blog (https://www.elastic.co/blog/building-cloud-sandbox-with-sample-data-v2) updated as well, but even if people figure out how to get here this won't load properly