### PR TITLE
Download links are updated in Machine Learning/Security Analytics Recipes.

### DIFF
--- a/Machine Learning/Security Analytics Recipes/dns_data_exfiltration/EXAMPLE.md
+++ b/Machine Learning/Security Analytics Recipes/dns_data_exfiltration/EXAMPLE.md
@@ -104,9 +104,9 @@ The Machine Learning Recipe can be loaded prior to the complete datacapture howe
 Download the following files to the same directory:
 
   ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/dns_data_exfiltration/machine_learning/data_feed.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/dns_data_exfiltration/machine_learning/job.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/dns_data_exfiltration/machine_learning/data_feed.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/dns_data_exfiltration/machine_learning/job.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
   ```
 
 * Load the Job by running the supplied reset_job.sh script.

--- a/Machine Learning/Security Analytics Recipes/http_data_exfiltration/EXAMPLE.md
+++ b/Machine Learning/Security Analytics Recipes/http_data_exfiltration/EXAMPLE.md
@@ -60,7 +60,7 @@ This example includes:
 * Download the provided Packetbeat configuration file.
 
     ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/http_data_exfiltration/configs/packetbeat/packetbeat.yml
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/http_data_exfiltration/configs/packetbeat/packetbeat.yml
     ```
 
 * Modify the packetbeat.yml file. Consider changing:
@@ -102,9 +102,9 @@ The Machine Learning Recipe can be loaded prior to the complete datacapture howe
 Download the following files to the **same directory**:
 
   ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/http_data_exfiltration/machine_learning/data_feed.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/http_data_exfiltration/machine_learning/job.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/http_data_exfiltration/machine_learning/data_feed.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/http_data_exfiltration/machine_learning/job.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
   ```
 
 * Load the Job by running the supplied reset_job.sh script.

--- a/Machine Learning/Security Analytics Recipes/suspicious_login_activity/EXAMPLE.md
+++ b/Machine Learning/Security Analytics Recipes/suspicious_login_activity/EXAMPLE.md
@@ -60,7 +60,7 @@ This example includes:
 * Download the test dataset provided.
 
     ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/data/auth.log
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/data/auth.log
     ```
 
 
@@ -69,7 +69,7 @@ This example includes:
 * Download the provided Filebeat configuration file.
 
     ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/configs/filebeat/filebeat.yml
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/configs/filebeat/filebeat.yml
     ```
 
 * Modify the filebeat.yml file. Change:
@@ -105,9 +105,9 @@ The above steps should index a sample set of auth logs into Elasticsearch.  To l
 Download the following files to the **same directory**:
 
   ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/machine_learning/data_feed.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/machine_learning/job.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/machine_learning/data_feed.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_login_activity/machine_learning/job.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
   ```
 
 * Load the Job by running the supplied reset_job.sh script.

--- a/Machine Learning/Security Analytics Recipes/suspicious_process_activity/EXAMPLE.md
+++ b/Machine Learning/Security Analytics Recipes/suspicious_process_activity/EXAMPLE.md
@@ -64,7 +64,7 @@ This example includes:
 
 * Download the provided Filebeat configuration file. This configuration utilises the [Auditd filebeat module](https://www.elastic.co/guide/en/beats/filebeat/5.4/filebeat-module-auditd.html) .
 
-    ```curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_process_activity/configs/filebeat/filebeat.yml```
+    ```curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_process_activity/configs/filebeat/filebeat.yml```
 
 * Modify the filebeat.yml file. Consider changing:
 
@@ -106,9 +106,9 @@ The Machine Learning Recipe can be loaded prior to the complete data capture how
 Download the following files to the same directory:
 
   ```
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_process_activity/machine_learning/data_feed.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_process_activity/machine_learning/job.json
-    curl -O https://github.com/elastic/examples/blob/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_process_activity/machine_learning/data_feed.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/suspicious_process_activity/machine_learning/job.json
+    curl -O https://raw.githubusercontent.com/elastic/examples/master/Machine%20Learning/Security%20Analytics%20Recipes/scripts/reset_job.sh
   ```
 
 * Load the Job by running the supplied reset_job.sh script.


### PR DESCRIPTION
I was trying to do Security Analytics Recipes.I had problem with Curl download links. These download links might be more useful.