### PR TITLE
Change type term

### DIFF
--- a/Alerting/Sample Watches/monitoring_cluster_health/watch.json
+++ b/Alerting/Sample Watches/monitoring_cluster_health/watch.json
@@ -29,7 +29,7 @@
                     },
                     {
                       "term": {
-                        "type" : "cluster_state"
+                        "type" : "cluster_stats"
                       }
                     }
                   ]


### PR DESCRIPTION
Monitoring does not create any documents with type set to "cluster_state". Instead, the type is set to "cluster_stats".