### PR TITLE
Remove _all in apache_template.json

### DIFF
--- a/Common Data Formats/apache_logs/logstash/apache_template.json
+++ b/Common Data Formats/apache_logs/logstash/apache_template.json
@@ -56,9 +56,6 @@
            "@version": {
               "type": "keyword"
            }
-        },
-        "_all": {
-           "enabled": true
         }
      }
   }


### PR DESCRIPTION
Fix template, `_all` has been disabled in `6.0`.