### PR TITLE
Add watching the Elastic watcher

### DIFF
--- a/Alerting/watching_the_elastic_watcher/Makefile
+++ b/Alerting/watching_the_elastic_watcher/Makefile
@@ -1,0 +1,12 @@
+PREFIX ?= /usr/local
+
+install:
+	install -d $(DESTDIR)/etc/watching_the_elastic_watcher/watches
+	install -m 0644 watches/* $(DESTDIR)/etc/watching_the_elastic_watcher/watches/
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -m 0755 watching_the_elastic_watcher $(DESTDIR)$(PREFIX)/bin/
+	install -d $(DESTDIR)/etc/systemd/system/
+	install -m 0644 systemd/* $(DESTDIR)/etc/systemd/system/
+	systemctl daemon-reload
+	systemctl enable watching_the_elastic_watcher.timer
+	systemctl start watching_the_elastic_watcher.timer

--- a/Alerting/watching_the_elastic_watcher/README.md
+++ b/Alerting/watching_the_elastic_watcher/README.md
@@ -1,0 +1,49 @@
+# Watching the Elastic watcher
+
+Elastic Watcher is very flexible and powerful. When you use this feature you start to depend on the correct behavior of the Elastic Watcher engine and the execution of your watches. "Trust is good, control is better", so you might want to monitor the Elastic Watcher. Watching the watcher so to speak. To effectively do that you need something like Elastic Watcher but outside of the system because if Elastic Watcher fails, it could not alert you of it.
+
+## Implementation
+
+To address this issue, the core functionally of Watcher has been re-implemented in a Python script. It understands a similar watch definition syntax that Elastic Watcher supports. Systemd timer is used to run to ensure that no interval is skipped due to scheduling time shifts over time that can occur when scheduling based on timer delays instead of realtime (i.e. wallclock) intervals.
+
+To transform watcher payload, Python code can be used as the only supported language. Painless is not supported.
+
+Currently only email as action is supported.
+
+## Watches
+
+### watcher_history_errors.yaml
+
+Watch for errors in `.watcher-history-*` and alert via Email. This finds errors like timeout_exception.
+
+### watcher_history_running.yaml
+
+Check the number of run watches against thresholds specific to each watch. This will find watches that have not triggered the number of times you specified or more times.
+
+For this to work, we need to know the schedule definition of the watch to check. It is suggested that watches expose their schedule interval using Elastic Watcher metadata. Example of a watch that runs every minute:
+
+```YAML
+metadata:
+  time_window: '1m'
+```
+
+This metadata field has other uses as well. Refer to https://discuss.elastic.co/t/ensure-that-watcher-does-not-miss-documents-logs/127780/1.
+
+If you want to check Elastic watches outside of your control, you can also define the schedule interval in our watch definition.
+
+## Dependencies
+
+Python3 and the following Python packages:
+
+* PyYAML
+* pystache
+* systemd-python
+* elasticsearch
+
+Additionally, to run the watches provided, you will need those Python packages as well:
+
+* pytimeparse
+
+## TODO
+
+Watch action that hooks into Monitoring systems instead of direct Email alerting.

--- a/Alerting/watching_the_elastic_watcher/systemd/watching_the_elastic_watcher.service
+++ b/Alerting/watching_the_elastic_watcher/systemd/watching_the_elastic_watcher.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Run watching_the_elastic_watcher.
+
+[Service]
+Type=oneshot
+
+ExecStart=/usr/local/bin/watching_the_elastic_watcher --journald --quiet --watch-file /etc/watching_the_elastic_watcher/watches/watcher_history_errors.yaml
+ExecStart=/usr/local/bin/watching_the_elastic_watcher --journald --quiet --watch-file /etc/watching_the_elastic_watcher/watches/watcher_history_running.yaml

--- a/Alerting/watching_the_elastic_watcher/systemd/watching_the_elastic_watcher.timer
+++ b/Alerting/watching_the_elastic_watcher/systemd/watching_the_elastic_watcher.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Trigger watcher_history_errors.yaml using watching_the_elastic_watcher.
+
+[Timer]
+OnCalendar=00/2:25:00
+Persistent=true
+
+[Install]
+WantedBy=multi-user.target

--- a/Alerting/watching_the_elastic_watcher/watches/watcher_history_errors.yaml
+++ b/Alerting/watching_the_elastic_watcher/watches/watcher_history_errors.yaml
@@ -1,0 +1,113 @@
+---
+
+# yamllint disable rule:line-length rule:comments-indentation
+
+metadata:
+  name: 'watching_the_elastic_watcher'
+  comment: 'Errors in .watcher-history-*'
+
+## We never want to throttle/drop actions.
+throttle_period: '0s'
+
+input:
+  search:
+    timeout: '5m'
+    request:
+      type: 'scroll'
+
+      indices:
+        - '.watcher-history-*'
+
+      body:
+
+        # size: 100
+
+        _source:
+          includes:
+            - 'watch_id'
+            - 'exception'
+
+        query:
+          bool:
+            must:
+
+              - query_string:
+                  query: "+state:(failed)"
+
+              - range:
+                  'trigger_event.triggered_time':
+                    # Ref for details: https://discuss.elastic.co/t/ensure-that-watcher-does-not-miss-documents-logs/127780/1
+                    # gte: 'now-44h/h'
+                    gte: 'now-2h-5m/h'
+                    lt: 'now-5m/h'
+
+        # aggregations:
+
+        #   watch_id:
+        #     terms:
+        #       field: 'watch_id'
+        #       size: 1000
+
+        #     aggregations:
+        #       exception.caused_by.reason:
+        #         terms:
+        #           field: 'exception.caused_by.reason'
+        #           size: 1000
+        #
+
+transform:
+  script:
+    source: |-
+      aggr = {}
+
+      for hit in ctx['scan']:
+          if 'exception' in hit['_source']:
+              key = '{}_{}'.format(
+                  hit['_source']['watch_id'],
+                  hit['_source']['exception']['type'],
+              )
+              if key in aggr:
+                  aggr[key]['count'] += 1
+              else:
+                  aggr[key] = {
+                      'count': 1,
+                      'keys': (
+                          hit['_source']['watch_id'],
+                          hit['_source']['exception']['type'],
+                      ),
+                  }
+
+      if len(aggr):
+          msg_body_lines = [
+              'count, watch_id, exception_type',
+              ''
+          ]
+          for k in sorted(aggr, key=lambda x: (-aggr[x]['count'], x)):
+              hit = aggr[k]
+              msg_body_lines.append('{count}, {watch_id}, {exception_type}'.format(
+                  count=hit['count'],
+                  watch_id=hit['keys'][0],
+                  exception_type=hit['keys'][1],
+              ))
+
+          # \t is used as workaround for not behaving MUAs.
+          # Ref: https://stackoverflow.com/questions/247546/outlook-autocleaning-my-line-breaks-and-screwing-up-my-email-format/436114#436114
+          ctx['payload'] = '\t\n'.join(msg_body_lines)
+
+actions:
+  send_email:
+
+    email:
+      from: 'something@geberit.com'
+
+      ## Not supported in the Python version of Muctache. It works in Elastic Watcher.
+      # to: '{{#join}}ctx.metadata.email_recipient_groups.ITS_INS_elastic_and_monitoring{{/join}}'
+
+      to:
+        - 'Robin Schneider <robin.schneider@geberit.com>'
+      reply_to:
+        - 'Robin Schneider <robin.schneider@geberit.com>'
+
+      subject: '{{ctx.metadata.name}}: {{ctx.metadata.comment}}'
+      body:
+        text: '{{ctx.payload}}'

--- a/Alerting/watching_the_elastic_watcher/watches/watcher_history_running.yaml
+++ b/Alerting/watching_the_elastic_watcher/watches/watcher_history_running.yaml
@@ -1,0 +1,164 @@
+---
+
+# yamllint disable rule:line-length rule:comments-indentation
+
+metadata:
+  name: 'watching_the_elastic_watcher'
+  comment: 'Watches did not trigger the number of times matching their schedule specification.'
+
+  time_window: '2h'
+
+## We never want to throttle/drop actions.
+throttle_period: '0s'
+
+input:
+  search:
+    timeout: '5m'
+    request:
+      type: 'search'
+
+      indices:
+        - '.watcher-history-*'
+
+      body:
+
+        size: 0
+
+        query:
+          bool:
+            must:
+
+              # - query_string:
+              #     query: '+trigger_event.triggered_time:>"2019-08-01T11:01:23.416Z"'
+
+              - range:
+                  'trigger_event.triggered_time':
+                    # Ref for details: https://discuss.elastic.co/t/ensure-that-watcher-does-not-miss-documents-logs/127780/1
+                    # gte: 'now-12h-5m/h'
+                    gte: 'now-2h-5m/h'
+                    lt: 'now-5m/h'
+
+        aggregations:
+
+          watch_id:
+            terms:
+              field: 'watch_id'
+              size: 1000
+
+            aggregations:
+              watch_with_time_window_metadata:
+                filter:
+                  query_string:
+                    query: '+_exists_:(metadata.time_window)'
+
+                aggregations:
+                  metadata.time_window:
+                    ## FIXME: Handle the case when a the time_window of a watch
+                    ## is changed.
+                    terms:
+                      field: 'metadata.time_window.keyword'
+                      size: 1000
+
+              watch_without_time_window_metadata:
+                filter:
+                  query_string:
+                    query: '-_exists_:(metadata.time_window)'
+                    # query: '+_exists_:(metadata.time_window)'
+
+                aggregations:
+                  time_window:
+                    filters:
+                      other_bucket_key: 'unclassified'
+                      filters:
+
+                        # Even if you don’t use this feature, you need to leave
+                        # this aggregation enabled because it is also used to
+                        # find unclassified watches. That is what this is for.
+                        'dummy_to_keep_syntax_valid_if_all_other_disabled':
+                          query_string:
+                            query: '-_exists_:watch_id'
+
+
+                        # '5m':
+                        #   bool:
+                        #     should:
+                        #       - query_string:
+                        #               query: '+watch_id:(some_watch_id OR some_other_watch_id)'
+
+transform:
+  script:
+    source: |-
+      import pytimeparse
+
+      def handle_compare_time_windows(msg_body_lines, watch, expected_tw_s, actual_tw_s):
+          if abs(expected_tw_s - actual_tw_s) != 0:
+              msg_body_lines.append('Watch ID: {}, Actual time window: {}s, expected time window: {}s'.format(
+                  watch['key'],
+                  expected_tw_s,
+                  actual_tw_s,
+              ))
+
+
+      msg_body_lines = []
+
+      if ctx['payload']['aggregations']['watch_id']['sum_other_doc_count'] != 0:
+          msg_body_lines.append("ES found more aggregated hosts than we assumed. Number of unprocessed hosts: {}".format(
+              ctx['payload']['aggregations']['watch_id']['sum_other_doc_count'],
+          ))
+
+
+      monitoring_time_window_seconds = pytimeparse.parse(ctx['metadata']['time_window'])
+
+      for watch in ctx['payload']['aggregations']['watch_id']['buckets']:
+          actual_run_count = watch['doc_count']
+          for time_window_bucket in watch.get('watch_with_time_window_metadata', {}).get('metadata.time_window', {}).get('buckets', []):
+              expected_time_window_seconds = pytimeparse.parse(time_window_bucket['key'])
+              actual_time_window_seconds = monitoring_time_window_seconds / actual_run_count
+
+              handle_compare_time_windows(
+                  msg_body_lines,
+                  watch,
+                  expected_time_window_seconds,
+                  actual_time_window_seconds,
+              )
+
+          for expected_time_window, time_window_bucket in watch.get('watch_without_time_window_metadata', {}).get('time_window', {}).get('buckets', {}).items():
+              if time_window_bucket['doc_count'] > 0:
+                  if expected_time_window == 'unclassified':
+                      msg_body_lines.append("The interval for {} is not defined.".format(
+                          watch['key'],
+                      ))
+                  else:
+                      expected_time_window_seconds = pytimeparse.parse(expected_time_window)
+                      actual_time_window_seconds = monitoring_time_window_seconds / actual_run_count
+
+                      handle_compare_time_windows(
+                          msg_body_lines,
+                          watch,
+                          expected_time_window_seconds,
+                          actual_time_window_seconds,
+                      )
+
+      ctx.pop('payload', None)
+      if len(msg_body_lines):
+          # \t is used as workaround for not behaving MUAs.
+          # Ref: https://stackoverflow.com/questions/247546/outlook-autocleaning-my-line-breaks-and-screwing-up-my-email-format/436114#436114
+          ctx['payload'] = '\t\n'.join(msg_body_lines)
+
+actions:
+  send_email:
+
+    email:
+      from: 'something@geberit.com'
+
+      ## Not supported in the Python version of Muctache. It works in Elastic Watcher.
+      # to: '{{#join}}ctx.metadata.email_recipient_groups.ITS_INS_elastic_and_monitoring{{/join}}'
+
+      to:
+        - 'Robin Schneider <robin.schneider@geberit.com>'
+      reply_to:
+        - 'Robin Schneider <robin.schneider@geberit.com>'
+
+      subject: '{{ctx.metadata.name}}: {{ctx.metadata.comment}}'
+      body:
+        text: '{{ctx.payload}}'

--- a/Alerting/watching_the_elastic_watcher/watching_the_elastic_watcher
+++ b/Alerting/watching_the_elastic_watcher/watching_the_elastic_watcher
@@ -1,0 +1,210 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+"""
+Quick and dirty impelemntation of Elasticsearch watcher in Python. The watch
+definition is kept very similar to the original.  The main use case for this
+watcher outside of Elasticsearch is to monitor the operation of Elasticsearch
+watches because those watches cannot effectively be used to watch themselves.
+"""
+
+__version__ = '0.1.0'
+__license__ = 'AGPL-3.0-only'
+__author__ = 'Robin Schneider <robin.schneider@geberit.com>'
+__copyright__ = [
+    'Copyright (C) 2019 Robin Schneider <robin.schneider@geberit.com>',
+    'Copyright (C) 2019 Geberit Verwaltungs GmbH https://www.geberit.de',
+]
+
+import sys
+import logging
+import argparse
+import json
+import smtplib
+import traceback
+
+from email.message import EmailMessage
+
+import yaml
+import pystache
+from systemd.journal import JournalHandler
+from elasticsearch import Elasticsearch
+from elasticsearch.helpers import scan
+
+
+class SetJSONEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, set):
+            return list(obj)
+        return json.JSONEncoder.default(self, obj)
+
+
+class LogExtraAsJsonDataAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        if 'extra' in kwargs:
+            kwargs['extra'] = {'JSON_SD': json.dumps(kwargs['extra'], cls=SetJSONEncoder)}
+        return msg, kwargs
+
+
+_LOG = logging.getLogger(__name__)
+LOG = LogExtraAsJsonDataAdapter(_LOG, {})
+# Please always log structured data.
+# Ref: https://stackify.com/what-is-structured-logging-and-why-developers-need-it/
+# Follow ECS if possible: https://github.com/elastic/ecs/blob/master/docs/field-details.asciidoc
+
+
+def get_args_parser():
+    args_parser = argparse.ArgumentParser(
+        epilog=__doc__,
+    )
+    args_parser.add_argument(
+        '-c', '--curator-file',
+        help="File path to curator YAML file used to get Elasticsearch entpoint and credentials.",
+        default='/etc/curator/curator.yml',
+    )
+    args_parser.add_argument(
+        '-w', '--watch-file',
+        help="File path to watch YAML file.",
+        required=True,
+    )
+    args_parser.add_argument(
+        '-n', '--dry-run', help="Trail run without changing anything.",
+        action="store_true",
+    )
+    args_parser.add_argument(
+        '-d', '--debug',
+        help="Write debugging and higher to STDOUT|STDERR.",
+        action="store_const",
+        dest="loglevel",
+        const=logging.DEBUG,
+    )
+    #  args_parser.add_argument(
+    #      '-v', '--verbose',
+    #      help="Write information and higher to STDOUT|STDERR.",
+    #      action="store_const",
+    #      dest="loglevel",
+    #      const=logging.INFO,
+    #  )
+    args_parser.add_argument(
+        '-q', '--quiet', '--silent',
+        help="Only write errors and higher to STDOUT|STDERR.",
+        action="store_const",
+        dest="loglevel",
+        const=logging.ERROR,
+    )
+    args_parser.add_argument(
+        '-j', '--journald',
+        help="Log to systemd-journald.",
+        action="store_true",
+    )
+    args_parser.add_argument(
+        '-V', '--version',
+        action='version',
+        version='%(prog)s {version}'.format(version=__version__),
+    )
+
+    args_parser.set_defaults(loglevel=logging.INFO)
+
+    return args_parser
+
+
+if __name__ == '__main__':
+    args_parser = get_args_parser()
+    args = args_parser.parse_args()
+
+    if args.journald and args.loglevel == logging.ERROR:
+        args.loglevel = logging.CRITICAL
+
+    _LOG.setLevel(logging.DEBUG)
+    log_stderr_handler = logging.StreamHandler(sys.stdout)
+    log_stderr_handler.setLevel(args.loglevel)
+    log_stderr_handler.setFormatter(logging.Formatter(
+        '%(levelname)s{dry_run}{pos}, %(asctime)s: %(message)s'.format(
+            dry_run=', DRY RUN' if args.dry_run else '',
+            pos=' (%(filename)s:%(lineno)s)' if args.loglevel <= logging.DEBUG else '',
+        )
+    ))
+    _LOG.addHandler(log_stderr_handler)
+
+    def exception_logger(type, value, tb):
+        LOG.exception("Uncaught exception: {0}".format(str(value)))
+    if args.journald:
+        _LOG.addHandler(JournalHandler(SYSLOG_IDENTIFIER='watching_the_elastic_watcher'))
+        sys.excepthook = exception_logger
+
+    ctx = {}
+
+    try:
+        with open(args.watch_file, 'r') as s_fh:
+            watch_definition = yaml.safe_load(s_fh.read())
+
+        ctx['metadata'] = watch_definition['metadata']
+
+        with open(args.curator_file, 'r') as c_fh:
+            curator_config = yaml.safe_load(c_fh.read())
+
+        es_creds = curator_config['client']['http_auth'].split(':')
+        es_url = 'http{}://{}:{}'.format(
+            's' if curator_config['client'].get('use_ssl', True) else '',
+            curator_config['client']['hosts'][0],
+            curator_config['client'].get('port', 9200),
+        )
+        es_cacert = curator_config['client'].get('certificate')
+
+        es = Elasticsearch(
+            es_url,
+            http_auth=(es_creds[0], es_creds[1]),
+            ca_certs=es_cacert,
+        )
+
+        LOG.info("Executing ElasticSearch search: {}".format(watch_definition['input']['search']))
+
+        if watch_definition['input']['search']['request']['type'] == 'scroll':
+            ctx['scan'] = scan(
+                es,
+                index=watch_definition['input']['search']['request']['indices'],
+                query=watch_definition['input']['search']['request']['body'],
+                timeout=watch_definition['input']['search'].get('timeout', 10),
+            )
+        else:
+            ctx['payload'] = es.search(
+                index=watch_definition['input']['search']['request']['indices'],
+                body=watch_definition['input']['search']['request']['body'],
+                timeout=watch_definition['input']['search'].get('timeout', 10),
+            )
+            if args.loglevel <= logging.DEBUG:
+                LOG.debug("Elasticsearch response: {}".format(
+                    json.dumps(
+                        ctx['payload'],
+                        sort_keys=True,
+                        indent=4
+                    ),
+                ))
+
+        exec(watch_definition['transform']['script']['source'], {'ctx': ctx})
+    except:
+        ctx['payload'] = traceback.format_exc()
+
+    if 'payload' in ctx:
+
+        for action_id, action in watch_definition['actions'].items():
+            for action_type, action_def in action.items():
+
+                if action_type == 'email':
+
+                    # Create the base text message.
+                    msg = EmailMessage()
+                    msg['Subject'] = pystache.render(action_def['subject'], {'ctx': ctx})
+                    msg['From'] = action_def['from']
+                    msg['To'] = action_def['to']
+                    if 'reply_to' in action_def:
+                        msg['Reply-To'] = action_def['reply_to']
+                    msg.set_content(pystache.render(action_def['body']['text'], {'ctx': ctx}))
+
+                    LOG.info("Sending email:\n{}".format(
+                        msg,
+                    ))
+
+                    if not args.dry_run:
+                        with smtplib.SMTP('localhost') as s:
+                            s.send_message(msg)


### PR DESCRIPTION
Elastic Watcher is very flexible and powerful. When you use this feature you start to depend on the correct behavior of the Elastic Watcher engine and the execution of your watches. "Trust is good, control is better", so you might want to monitor the Elastic Watcher. Watching the watcher so to speak. To effectively do that you need something like Elastic Watcher but outside of the system because if Elastic Watcher fails, it could not alert you of it.

Refer to https://github.com/ypid-geberit/examples/tree/add/watching_the_elastic_watcher/Alerting/watching_the_elastic_watcher for details.