### PR TITLE
Update SIEM-at-Home examples

### DIFF
--- a/Security Analytics/SIEM-at-Home/README.md
+++ b/Security Analytics/SIEM-at-Home/README.md
@@ -1,2 +1,19 @@
 # Elastic-SIEM-at-Home
 References and examples for deploying an Elastic SIEM at Home running on Elastic Cloud
+
+## beats-configs
+Example configurations for beats when deploying an Elastic SIEM at Home running on Elasticsearch Service
+
+Use the `General`, `Elastic Cloud`, and `Xpack Monitoring` sections within the `beats-general-config.yml` file for configurations used for all beats.
+
+This example includes:
+* Filebeat configuration for reference
+* Packetbeat configuration for reference
+* Winlogbeat configuration for reference
+
+### Beats Privileges
+For version 7.4, see documentation for each specific beat:
+* [Auditbeat](https://www.elastic.co/guide/en/beats/auditbeat/7.4/feature-roles.html#privileges-to-setup-beats)
+* [Filebeat](https://www.elastic.co/guide/en/beats/filebeat/7.4/feature-roles.html#privileges-to-setup-beats)
+* [Packetbeat](https://www.elastic.co/guide/en/beats/packetbeat/7.4/feature-roles.html#privileges-to-setup-beats)
+* [Winlogbeat](https://www.elastic.co/guide/en/beats/winlogbeat/7.4/feature-roles.html#privileges-to-setup-beats)

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml
@@ -26,8 +26,8 @@ processors:
       when.network.source.ip: private
       fields:
         source.geo.location:
-          lat: 40.78
-          lon: -73.97
+          lat: 40.7128
+          lon: -74.0060
         source.geo.continent_name: North America
         source.geo.region_iso_code: US-NY
         source.geo.country_iso_code: US
@@ -39,8 +39,8 @@ processors:
       when.network.destination.ip: private
       fields:
         destination.geo.location:
-          lat: 40.78
-          lon: -73.97
+          lat: 40.7128
+          lon: -74.0060
         destination.geo.continent_name: North America
         destination.geo.region_iso_code: US-NY
         destination.geo.country_iso_code: US
@@ -53,8 +53,23 @@ processors:
 cloud.id: "My_Elastic_Cloud_Deployment:abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 cloud.auth: "data_shipper:0987654321abcDEF"
 
+# The `max_retries` setting is the number of times to retry publishing an event after 
+# a publishing failure. After the specified number of retries, the events are typically dropped.
+output.elasticsearch.max_retries: 5
+
 # When deploying beats to multiple systems or locations, uncomment the following 
 # setup.template.* and setup.ilm.* configurations after running the beats setup command
 #setup.template.enabled: false
 #setup.ilm.check_exists: false
 #setup.ilm.overwrite: false
+
+#================================= Queue ======================================
+# See the 'Configure the internal queue' documentation for each beat before 
+# configuring the queue.  Note that only one queue type can be configured.
+# The `queue.mem` settings will cache events to memory in case the system is offline
+queue.mem:
+  events: 4096
+  flush.min_events: 512
+  flush.timeout: 1s
+# The `queue.spool` settings will cache events to disk in case the system is offline
+# NOTE: The file spool queue is a beta functionality in 7.4

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml
@@ -8,6 +8,8 @@ fields:
 #========================== Top Level Processor ===============================
 processors:
   - add_host_metadata:
+      # netinfo.enabled should be set to `false` in packetbeat until GitHub
+      # issue https://github.com/elastic/elasticsearch/issues/46193 is closed
       netinfo.enabled: true
       Geo: # These Geo configurations are optional
         name: myHomeLocation
@@ -50,3 +52,9 @@ processors:
 # These settings simplify using beats with the Elastic Cloud (https://cloud.elastic.co/).
 cloud.id: "My_Elastic_Cloud_Deployment:abcdefghijklmnopqrstuvwxyz1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 cloud.auth: "data_shipper:0987654321abcDEF"
+
+# When deploying beats to multiple systems or locations, uncomment the following 
+# setup.template.* and setup.ilm.* configurations after running the beats setup command
+#setup.template.enabled: false
+#setup.ilm.check_exists: false
+#setup.ilm.overwrite: false


### PR DESCRIPTION
Changes in this PR:
1. `beats-general-config.yml` - Add comment regarding `netinfo.enabled` setting and added a section to disable beats setup within the configuration file

2. `README.md` - Provide additional information regarding the `beats-configs` in this example

3. `beats-general-config.yml` - Define `output.elasticsearch.max_retries: 5`, define `queue.mem` settings, notate `queue.spool`; update `destination.geo.location` and `source.geo.location` to match the host geo location