### PR TITLE
SIEM-at-Home example updates 20191211

### DIFF
--- a/Security Analytics/SIEM-at-Home/README.md
+++ b/Security Analytics/SIEM-at-Home/README.md
@@ -4,7 +4,7 @@ Monitoring your servers and workstations doesn't have to be difficult or expensi
 2. [Securing cluster access](https://www.elastic.co/blog/elastic-siem-for-small-business-and-home-2-securing-cluster-access)
 3. [GeoIP data and Beats config review](https://www.elastic.co/blog/elastic-siem-for-small-business-and-home-3-geoip-data-and-beats-config-review)
 4. [Beats on Windows](https://www.elastic.co/blog/elastic-siem-for-small-business-and-home-4-beats-on-windows)
-
+5. Beats on CentOS  _(coming soon)_
 
 ## `beats-configs`
 Example configurations for beats when deploying an Elastic SIEM at Home running on Elasticsearch Service

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/auditbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/auditbeat.yml
@@ -46,6 +46,18 @@ auditbeat.modules:
         target: process.parent
   period: 5s
 
+#=== Auditbeat logging ===
+# Configure logging for Auditbeat if you plan on using the GeoIP ingest processor
+# Initially use `info` for the logging.level, set logging.level to `debug` if you see
+# an `Failed to publish events: temporary bulk send failure` error message in the logs
+#logging.level: info
+#logging.to_files: true
+#logging.files:
+#  path: /var/log/elastic
+#  name: auditbeat
+#  keepfiles: 7
+#  permissions: 0644
+
 #=== Beats Common Configs Here ===
 # Add the settings from the Beats General Config file (beats-general-config.yml)
 # to the end of this configuration file. The Beats General Config file example can be found at this link:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/auditbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/auditbeat.yml
@@ -1,5 +1,5 @@
 # Example for the Beats on CentOS blog
-# Configuration version: 11-27-2019
+# Configuration version: 12-11-2019
 #=== Auditbeat specific options ===
 #===  Modules configuration ===
 auditbeat.modules:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/filebeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/filebeat.yml
@@ -47,6 +47,18 @@ filebeat.inputs:
     app: pihole
     name: pihole-lighttpd
 
+#=== Filebeat logging ===
+# Configure logging for Filebeat if you plan on using the GeoIP ingest processor
+# Initially use `info` for the logging.level, set logging.level to `debug` if you see
+# an `Failed to publish events: temporary bulk send failure` error message in the logs
+#logging.level: info
+#logging.to_files: true
+#logging.files:
+#  path: /var/log/elastic
+#  name: filebeat
+#  keepfiles: 7
+#  permissions: 0644
+
 #=== Beats Common Configs Here ===
 # Add the settings from the Beats General Config file (beats-general-config.yml)
 # to the end of this configuration file. The Beats General Config file example can be found at this link:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/filebeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/filebeat.yml
@@ -14,6 +14,7 @@ filebeat.inputs:
   enabled: true
   paths:
     - /var/log/yum.log
+  close_inactive: 1m
 
 - type: log
   enabled: true

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/filebeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/filebeat.yml
@@ -1,5 +1,5 @@
 # Example for the Beats on CentOS blog
-# Configuration version: 11-27-2019
+# Configuration version: 12-11-2019
 #=== Filebeat specific options ===
 #=== Filebeat modules ===
 filebeat.config.modules:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/packetbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/packetbeat.yml
@@ -1,5 +1,5 @@
 # Example for the Beats on CentOS blog
-# Configuration version: 11-27-2019
+# Configuration version: 12-11-2019
 #=== Packetbeat specific options ===
 #=== Network device ===
 # Select the network interface to sniff the data. On Linux, you can use the

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/packetbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-centos/packetbeat.yml
@@ -51,6 +51,18 @@ packetbeat.protocols:
     - 8883  # Secure MQTT
     - 9243  # Elasticsearch
 
+#=== Packetbeat logging ===
+# Configure logging for Packetbeat if you plan on using the GeoIP ingest processor
+# Initially use `info` for the logging.level, set logging.level to `debug` if you see
+# an `Failed to publish events: temporary bulk send failure` error message in the logs
+#logging.level: info
+#logging.to_files: true
+#logging.files:
+#  path: /var/log/elastic
+#  name: packetbeat
+#  keepfiles: 7
+#  permissions: 0644
+
 #=== Beats Common Configs Here ===
 # Add the settings from the Beats General Config file (beats-general-config.yml)
 # to the end of this configuration file. The Beats General Config file example can be found at this link:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-windows/auditbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-windows/auditbeat.yml
@@ -1,5 +1,5 @@
 # Example for the Beats on Windows blog
-# Configuration version: 11-27-2019
+# Configuration version: 12-06-2019
 #=== Auditbeat specific options ===
 #===  Modules configuration ===
 auditbeat.modules:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-windows/packetbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-windows/packetbeat.yml
@@ -1,5 +1,5 @@
 # Example for the Beats on Windows blog
-# Configuration version: 11-27-2019
+# Configuration version: 12-06-2019
 #=== Packetbeat specific options ===
 #=== Network device ===
 # Issue the `.\packetbeat.exe devices` command to determine the interfaces on your system

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-windows/winlogbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-windows/winlogbeat.yml
@@ -1,5 +1,5 @@
 # Example for the Beats on Windows blog
-# Configuration version: 11-25-2019
+# Configuration version: 12-06-2019
 #=== Winlogbeat specific options ===
 winlogbeat.event_logs:
   - name: Application


### PR DESCRIPTION
SIEM-at-Home example updates on December 11, 2019:
1. Update `beats-on-centos/auditbeat.yml` - Include Auditbeat logging configuration example
2. Update `beats-on-centos/filebeat.yml` - Include Filebeat logging configuration example
3. Update `beats-on-centos/filebeat.yml` - Include `close_inactive` configuration example
4. Update `beats-on-centos/packetbeat.yml` - Include Packetbeat logging configuration example
5. Update `beats-on-windows/auditbeat.yml` - Update configuration version
6. Update `beats-on-windows/packetbeat.yml` - Update configuration version
7. Update `beats-on-windows/winlogbeat.yml` - Update configuration version
8. Update `beats-on-centos/auditbeat.yml` - Update configuration version
9. Update `beats-on-centos/filebeat.yml` - Update configuration version
10. Update `beats-on-centos/packetbeat.yml` - Update configuration version
11. Update SIEM-at-Home `README.md` - Add note regarding blog 5