### PR TITLE
SIEM at Home example updates

### DIFF
--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml
@@ -4,7 +4,7 @@ name: myHostName
 tags: ["myTag", "myHostName"]
 fields:
   env: myEnv
-  version: 11-26-2019
+  version: 12-18-2019
 
 #=== Top Level Processor ===
 processors:
@@ -21,8 +21,9 @@ processors:
         city_name: New York City
         name: myHomeLocation
   - add_locale: ~
-  - add_cloud_metadata: ~
+#  - add_cloud_metadata: ~
   - add_fields:
+      # Consider defining known subnets on portable systems instead of `private`
       #when.network.source.ip: 10.101.101.0/24
       when.network.source.ip: private
       fields:
@@ -37,6 +38,7 @@ processors:
         source.geo.name: myHomeLocation
       target: ''
   - add_fields:
+      # Consider defining known subnets on portable systems instead of `private`
       #when.network.destination.ip: 10.101.101.0/24
       when.network.destination.ip: private
       fields:

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-macOS/auditbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-macOS/auditbeat.yml
@@ -1,0 +1,53 @@
+# Example for the Beats on MacOS blog
+# Configuration version: 12-18-2019
+#=== Auditbeat specific options ===
+#===  Modules configuration ===
+auditbeat.modules:
+
+- module: file_integrity
+  paths:
+  - /bin
+  - /usr/bin
+  - /usr/local
+  - /sbin
+  - /usr/sbin
+  - /Applications
+  - /Library
+  - /System
+
+- module: system
+  datasets:
+    - package
+    - host
+  period: 30m
+  state.period: 12h
+
+- module: system
+  datasets:
+    - process 
+  processors:
+    - drop_event.when:
+         or:
+          - contains.event.action: "existing_process"
+          - contains.event.action: "process_error"
+    - add_process_metadata:
+        match_pids: [process.ppid]
+        target: process.parent
+  period: 5s
+
+#=== Auditbeat logging ===
+# Configure logging for Auditbeat if you plan on using the GeoIP ingest processor
+# Initially use `info` for the logging.level, set logging.level to `debug` if you see
+# an `Failed to publish events: temporary bulk send failure` error message in the logs
+#logging.level: info
+#logging.to_files: true
+#logging.files:
+#  path: /var/log/elastic
+#  name: auditbeat
+#  keepfiles: 7
+#  permissions: 0644
+
+#=== Beats Common Configs Here ===
+# Add the settings from the Beats General Config file (beats-general-config.yml)
+# to the end of this configuration file. The Beats General Config file example can be found at this link:
+# https://github.com/elastic/examples/blob/master/Security%20Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml

--- a/Security Analytics/SIEM-at-Home/beats-configs/beats-on-macOS/packetbeat.yml
+++ b/Security Analytics/SIEM-at-Home/beats-configs/beats-on-macOS/packetbeat.yml
@@ -1,0 +1,70 @@
+# Example for the Beats on MacOS blog
+# Configuration version: 12-18-2019
+#=== Packetbeat specific options ===
+#=== Network device ===
+# Issue the `packetbeat devices` command to determine the interfaces on your system
+# Select the network interface to sniff the data. On Linux, you can use the
+# "any" keyword to sniff on all connected interfaces.
+packetbeat.interfaces.device: 2
+
+#=== Flows ===
+packetbeat.flows:
+  timeout: 30s
+  period: 10s
+
+#=== Transaction protocols ===
+# For more information on the transaction protocols, see
+# https://www.elastic.co/guide/en/beats/packetbeat/7.4/configuration-protocols.html
+packetbeat.protocols:
+- type: icmp
+  # Enable ICMPv4 and ICMPv6 monitoring. Default: false
+  enabled: true
+
+- type: dhcpv4
+  # Configure the DHCP for IPv4 ports.
+  ports: [67, 68]
+  send_request: true
+  send_response: true
+
+- type: dns
+  # Configure the ports where to listen for DNS traffic. You can disable
+  # the DNS protocol by commenting out the list of ports.
+  ports: [53]
+  include_authorities: true
+  include_additionals: true
+  send_request: true
+  send_response: true
+
+- type: http
+  # Configure the ports where to listen for HTTP traffic. You can disable
+  # the HTTP protocol by commenting out the list of ports.
+  ports: [80, 8080, 8000, 5000, 8002]
+
+- type: tls
+  # Configure the ports where to listen for TLS traffic. You can disable
+  # the TLS protocol by commenting out the list of ports.
+  ports:
+    - 443   # HTTPS
+    - 993   # IMAPS
+    - 995   # POP3S
+    - 5223  # XMPP over SSL
+    - 8443
+    - 8883  # Secure MQTT
+    - 9243  # Elasticsearch
+
+#=== Packetbeat logging ===
+# Configure logging for Packetbeat if you plan on using the GeoIP ingest processor
+# Initially use `info` for the logging.level, set logging.level to `debug` if you see
+# an `Failed to publish events: temporary bulk send failure` error message in the logs
+#logging.level: info
+#logging.to_files: true
+#logging.files:
+#  path: /var/log/elastic
+#  name: packetbeat
+#  keepfiles: 7
+#  permissions: 0644
+
+#=== Beats Common Configs Here ===
+# Add the settings from the Beats General Config file (beats-general-config.yml)
+# to the end of this configuration file. The Beats General Config file example can be found at this link:
+# https://github.com/elastic/examples/blob/master/Security%20Analytics/SIEM-at-Home/beats-configs/beats-general-config.yml


### PR DESCRIPTION
SIEM at Home example updates:
1. Update `beats-general-config.yml` - Comment out the `add_cloud_metadata` processor within the Beats general configuration. Add comments to the `when.network.source.ip` and `when.network.destination.ip` sections.
2. Create `beats-on-macOS/auditbeat.yml` - Initial Auditbeat example for Beats on MacOS
3. Create `beats-on-macOS/packetbeat.yml` - Initial Packetbeat example for Beats on MacOS