### PR TITLE
updating to use new API versions

### DIFF
--- a/beats-k8s-send-anywhere/filebeat-kubernetes.yaml
+++ b/beats-k8s-send-anywhere/filebeat-kubernetes.yaml
@@ -98,7 +98,7 @@ data:
       host: ${KIBANA_HOST}
     
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: filebeat-dynamic
@@ -107,6 +107,10 @@ metadata:
     k8s-app: filebeat-dynamic
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat-dynamic
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:

--- a/beats-k8s-send-anywhere/metricbeat-kubernetes.yaml
+++ b/beats-k8s-send-anywhere/metricbeat-kubernetes.yaml
@@ -224,14 +224,18 @@ data:
 
 ---
 # Deploy a Metricbeat instance per node for node metrics retrieval
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
+
 metadata:
   name: metricbeat
   namespace: kube-system
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:
@@ -389,7 +393,7 @@ data:
       hosts: ["kube-state-metrics:8080"]
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metricbeat
@@ -397,6 +401,9 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:

--- a/beats-k8s-send-anywhere/packetbeat-kubernetes.yaml
+++ b/beats-k8s-send-anywhere/packetbeat-kubernetes.yaml
@@ -81,7 +81,7 @@ data:
       host: ${KIBANA_HOST}
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: packetbeat-dynamic
@@ -90,6 +90,10 @@ metadata:
     k8s-app: packetbeat-dynamic
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: packetbeat-dynamic
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:


### PR DESCRIPTION
fixes for https://github.com/elastic/examples/issues/307 where old versions of API will not work with new k8s.  
