### PR TITLE
Update url to the feature importance blog post

### DIFF
--- a/Machine Learning/Feature Importance/feature_importance_in_elasticsearch.ipynb
+++ b/Machine Learning/Feature Importance/feature_importance_in_elasticsearch.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "# Better Understand Your Data with Feature Importance and Data Frame Analytics\n",
     "\n",
-    "This is a companion notebook to the blog post."
+    "This is a companion notebook to the blog post [Feature importance for data frame analytics with Elastic machine learning](https://www.elastic.co/blog/feature-importance-for-data-frame-analytics-with-elastic-machine-learning)."
    ]
   },
   {


### PR DESCRIPTION
This PR simply puts an URL to the blog post where the notebook is used. No functional changes were made.