### PR TITLE
Fix example in examples/Cloud Enterprise/Getting Started Examples/aws/terraform

### DIFF
--- a/Cloud Enterprise/Getting Started Examples/aws/terraform/ansible-install.sh
+++ b/Cloud Enterprise/Getting Started Examples/aws/terraform/ansible-install.sh
@@ -120,7 +120,7 @@ _main() {
     _verify_ansible
     _write_ansible_playbook
     _write_ansible_hosts
-    sleep 30
+    sleep 90
     _run_ansible
 }
 

--- a/Cloud Enterprise/Getting Started Examples/aws/terraform/variables.tf
+++ b/Cloud Enterprise/Getting Started Examples/aws/terraform/variables.tf
@@ -74,7 +74,7 @@ variable "private_key" {
 # Ece version to be installed by ansible
 # Must be supported by the ansible playbook
 variable "ece-version" {
-  default="2.4.3"
+  default="2.5.0"
 }
 
 # ECE instances's VPC & Subnet cidr


### PR DESCRIPTION
fixes https://github.com/elastic/examples/issues/321

Increases timeout from 30 seconds to 90 seconds (worked 3 times in a row in tests) and bumps ECE version to 2.5.0