### PR TITLE
Update GKE on-prem example

### DIFF
--- a/GKE-On-Prem/filebeat-kubernetes.yaml
+++ b/GKE-On-Prem/filebeat-kubernetes.yaml
@@ -76,9 +76,9 @@ data:
     output.elasticsearch:
       hosts: ${ELASTICSEARCH_HOSTS}
       ilm.enabled: true
-    
+
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: filebeat-dynamic
@@ -87,6 +87,10 @@ metadata:
     k8s-app: filebeat-dynamic
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: filebeat-dynamic
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:

--- a/GKE-On-Prem/guestbook.yaml
+++ b/GKE-On-Prem/guestbook.yaml
@@ -164,7 +164,7 @@ metadata:
   labels:
     app: redis
     tier: backend
-    role: master
+    role: primary
 spec:
   ports:
   - port: 6379
@@ -172,7 +172,7 @@ spec:
   selector:
     app: redis
     tier: backend
-    role: master
+    role: primary
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -183,17 +183,17 @@ spec:
   selector:
     matchLabels:
       app: redis
-      role: master
+      role: primary
       tier: backend
   template:
     metadata:
       labels:
         app: redis
-        role: master
+        role: primary
         tier: backend
     spec:
       containers:
-      - name: master
+      - name: primary
         image: k8s.gcr.io/redis:e2e  # or just image: redis
         resources:
           requests:
@@ -219,14 +219,14 @@ metadata:
   labels:
     app: redis
     tier: backend
-    role: slave
+    role: replica
 spec:
   ports:
   - port: 6379
   selector:
     app: redis
     tier: backend
-    role: slave
+    role: replica
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -237,17 +237,17 @@ spec:
   selector:
     matchLabels:
       app: redis
-      role: slave
+      role: replica
       tier: backend
   template:
     metadata:
       labels:
         app: redis
-        role: slave
+        role: replica
         tier: backend
     spec:
       containers:
-      - name: slave
+      - name: replica
         image: gcr.io/google_samples/gb-redisslave:v1
         resources:
           requests:

--- a/GKE-On-Prem/guestbook.yaml
+++ b/GKE-On-Prem/guestbook.yaml
@@ -174,12 +174,17 @@ spec:
     tier: backend
     role: master
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-master
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: master
+      tier: backend
   template:
     metadata:
       labels:
@@ -223,12 +228,17 @@ spec:
     tier: backend
     role: slave
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: redis-slave
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+      role: slave
+      tier: backend
   template:
     metadata:
       labels:
@@ -271,12 +281,16 @@ spec:
     tier: frontend
   loadBalancerIP: 10.0.10.42
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: frontend
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: guestbook
+      tier: frontend
   template:
     metadata:
       labels:

--- a/GKE-On-Prem/journalbeat-kubernetes.yaml
+++ b/GKE-On-Prem/journalbeat-kubernetes.yaml
@@ -28,9 +28,9 @@ data:
     output.elasticsearch:
       hosts: ${ELASTICSEARCH_HOSTS}
       ilm.enabled: true
-    
+
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: journalbeat-dynamic
@@ -39,6 +39,10 @@ metadata:
     k8s-app: journalbeat-dynamic
     kubernetes.io/cluster-service: "true"
 spec:
+  selector:
+    matchLabels:
+      k8s-app: journalbeat-dynamic
+      kubernetes.io/cluster-service: "true"
   template:
     metadata:
       labels:

--- a/GKE-On-Prem/metricbeat-kubernetes.yaml
+++ b/GKE-On-Prem/metricbeat-kubernetes.yaml
@@ -101,7 +101,7 @@ data:
       period: 10s
       host: ${NODE_NAME}
       hosts: ["localhost:10255"]
-      # If using Red Hat OpenShift remove the previous hosts entry and 
+      # If using Red Hat OpenShift remove the previous hosts entry and
       # uncomment these settings:
       #hosts: ["https://${HOSTNAME}:10250"]
       #bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -110,7 +110,7 @@ data:
 
 ---
 # Deploy a Metricbeat instance per node for node metrics retrieval
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: metricbeat
@@ -118,6 +118,9 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
   template:
     metadata:
       labels:
@@ -237,7 +240,7 @@ data:
       hosts: ["kube-state-metrics:8080"]
 ---
 # Deploy singleton instance in the whole cluster for some unique data sources, like kube-state-metrics
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: metricbeat
@@ -245,6 +248,10 @@ metadata:
   labels:
     k8s-app: metricbeat
 spec:
+  selector:
+    matchLabels:
+      k8s-app: metricbeat
+
   template:
     metadata:
       labels:


### PR DESCRIPTION
Customers reported they couldn't complete the tutorial at https://cloud.google.com/solutions/partners/monitoring-gke-on-prem-with-the-elastic-stack without reporting any details. 

Assuming they're using a recent Kubernetes version that obsoletes our manifest files. Patched files work with `1.16.13-gke.401`

