### PR TITLE
Add csba file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ node_modules
 /ElasticStack_nyc_traffic_accidents/nyc_collision_data.csv
 /ElasticStack_twitter/twitter_logstash.conf.local
 *.idea*
+*.iml
 /ElasticStack_usfec/Scripts-Python+Logstash/data/
 /packetbeat_dns_tunnel_detection/dns-tunnel-iodine-timeshifted.pcap
 /dallas_crime_linking_with_graph/


### PR DESCRIPTION
Adds the census bureau metropolitan boundaries file used in the reverse-geocoding blog https://www.elastic.co/blog/how-to-map-custom-boundaries-in-kibana-with-reverse-geocoding