### PR TITLE
Anomaly Detection Jobs Archive

### DIFF
--- a/Machine Learning/Anomaly Detection/README.md
+++ b/Machine Learning/Anomaly Detection/README.md
@@ -6,14 +6,14 @@ TIP: Kibana can also recognize certain types of data and provide specialized
 wizards for that context. For more details, refer to
 [supplied anomaly detection configurations](https://www.elastic.co/guide/en/machine-learning/8.0/ootb-ml-jobs.html).
 
-Unsupervised ML Archive - Past Versions of the Anomaly Detection Jobs
+#### Unsupervised ML Archive - Past Versions of the Anomaly Detection Jobs
 
 These are prior versions of the version 3 ML jobs shipping in Elastic 8.3. They are only needed if running older data sources like Beats or Endpoints in the 7.x version range.
 
-security_linux: version 2 of the Linux anomaly detection jobs, from 2020.
-security_windows: version 2 of the Windows anomaly detection jobs, from 2020.
-siem_auditbeat: version 1 of the Linux anomaly detection jobs, from 2019.
-siem_winlogbeat: version 1 of the Windows anomaly detection jobs, from 2019.
+* security_linux: version 2 of the Linux anomaly detection jobs, from 2020.
+* security_windows: version 2 of the Windows anomaly detection jobs, from 2020.
 
-siem_winlogbeat_auth: an anomaly detection job for Windows RDP login events, from 2019.
-siem_auditbeat_auth: an anomaly detection job for auth events developed on Linux. The first ML job shipped in the Security solution.
+* siem_auditbeat: version 1 of the Linux anomaly detection jobs, from 2019.
+* siem_winlogbeat: version 1 of the Windows anomaly detection jobs, from 2019.
+* siem_winlogbeat_auth: an anomaly detection job for Windows RDP login events, from 2019.
+* siem_auditbeat_auth: an anomaly detection job for auth events developed on Linux. The first ML job shipped in the Security solution in 2019.

--- a/Machine Learning/Anomaly Detection/README.md
+++ b/Machine Learning/Anomaly Detection/README.md
@@ -5,3 +5,15 @@ This directory contains example anomaly detection job configurations.
 TIP: Kibana can also recognize certain types of data and provide specialized
 wizards for that context. For more details, refer to
 [supplied anomaly detection configurations](https://www.elastic.co/guide/en/machine-learning/8.0/ootb-ml-jobs.html).
+
+Unsupervised ML Archive - Past Versions of the Anomaly Detection Jobs
+
+These are prior versions of the version 3 ML jobs shipping in Elastic 8.3. They are only needed if running older data sources like Beats or Endpoints in the 7.x version range.
+
+security_linux: version 2 of the Linux anomaly detection jobs, from 2020.
+security_windows: version 2 of the Windows anomaly detection jobs, from 2020.
+siem_auditbeat: version 1 of the Linux anomaly detection jobs, from 2019.
+siem_winlogbeat: version 1 of the Windows anomaly detection jobs, from 2019.
+
+siem_winlogbeat_auth: an anomaly detection job for Windows RDP login events, from 2019.
+siem_auditbeat_auth: an anomaly detection job for auth events developed on Linux. The first ML job shipped in the Security solution.

--- a/Machine Learning/Anomaly Detection/security_linux/logo.json
+++ b/Machine Learning/Anomaly Detection/security_linux/logo.json
@@ -1,0 +1,3 @@
+{
+  "icon": "logoSecurity"
+}

--- a/Machine Learning/Anomaly Detection/security_linux/manifest.json
+++ b/Machine Learning/Anomaly Detection/security_linux/manifest.json
@@ -1,0 +1,104 @@
+{
+  "id": "security_linux",
+  "title": "Security: Linux",
+  "description": "Detect suspicious activity using ECS Linux events. Tested with Auditbeat and the Elastic agent.",
+  "type": "linux data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "auditbeat-*,logs-endpoint.events.*",
+  "query": {
+    "bool": {
+      "should": [
+        {
+          "match": {
+            "host.os.type": {
+              "query": "linux",
+              "operator": "OR"
+            }
+          }
+        },
+        {
+          "match": {
+            "host.os.family": {
+              "query": "debian",
+              "operator": "OR"
+            }
+          }
+        },
+        {
+          "match": {
+            "host.os.family": {
+              "query": "redhat",
+              "operator": "OR"
+            }
+          }
+        },
+        {
+          "match": {
+            "host.os.family": {
+              "query": "suse",
+              "operator": "OR"
+            }
+          }
+        }
+      ]
+    }
+  },
+  "jobs": [
+    {
+      "id": "v2_rare_process_by_host_linux_ecs",
+      "file": "v2_rare_process_by_host_linux_ecs.json"
+    },
+    {
+      "id": "v2_linux_rare_metadata_user",
+      "file": "v2_linux_rare_metadata_user.json"
+    },
+    {
+      "id": "v2_linux_rare_metadata_process",
+      "file": "v2_linux_rare_metadata_process.json"
+    },
+    {
+      "id": "v2_linux_anomalous_user_name_ecs",
+      "file": "v2_linux_anomalous_user_name_ecs.json"
+    },
+    {
+      "id": "v2_linux_anomalous_process_all_hosts_ecs",
+      "file": "v2_linux_anomalous_process_all_hosts_ecs.json"
+    },
+    {
+      "id": "v2_linux_anomalous_network_port_activity_ecs",
+      "file": "v2_linux_anomalous_network_port_activity_ecs.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-v2_rare_process_by_host_linux_ecs",
+      "file": "datafeed_v2_rare_process_by_host_linux_ecs.json",
+      "job_id": "v2_rare_process_by_host_linux_ecs"
+    },
+    {
+      "id": "datafeed-v2_linux_rare_metadata_user",
+      "file": "datafeed_v2_linux_rare_metadata_user.json",
+      "job_id": "v2_linux_rare_metadata_user"
+    },
+    {
+      "id": "datafeed-v2_linux_rare_metadata_process",
+      "file": "datafeed_v2_linux_rare_metadata_process.json",
+      "job_id": "v2_linux_rare_metadata_process"
+    },
+    {
+      "id": "datafeed-v2_linux_anomalous_user_name_ecs",
+      "file": "datafeed_v2_linux_anomalous_user_name_ecs.json",
+      "job_id": "v2_linux_anomalous_user_name_ecs"
+    },
+    {
+      "id": "datafeed-v2_linux_anomalous_process_all_hosts_ecs",
+      "file": "datafeed_v2_linux_anomalous_process_all_hosts_ecs.json",
+      "job_id": "v2_linux_anomalous_process_all_hosts_ecs"
+    },
+    {
+      "id": "datafeed-v2_linux_anomalous_network_port_activity_ecs",
+      "file": "datafeed_v2_linux_anomalous_network_port_activity_ecs.json",
+      "job_id": "v2_linux_anomalous_network_port_activity_ecs"
+    }
+  ]
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_anomalous_network_port_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_anomalous_network_port_activity_ecs.json
@@ -1,0 +1,76 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": 
+        {
+          "filter": [
+            {"term": {"event.category": "network"}},
+            {"term": {"event.type": "start"}}
+          ],
+          "must": [
+        {
+          "bool": {
+            "should": [
+               {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+                 {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+               {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {"term": {"destination.ip": "127.0.0.1"}},
+                  {"term": {"destination.ip": "::"}},
+                  {"term": {"destination.ip": "::1"}},
+                  {"term": {"user.name":"jenkins"}}
+                ]
+              }
+            }
+          ]
+        }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,101 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "user.name": "jenkins-worker"
+                }
+              },
+              {
+                "term": {
+                  "user.name": "jenkins-user"
+                }
+              },
+              {
+                "term": {
+                  "user.name": "jenkins"
+                }
+              },
+              {
+                "wildcard": {
+                  "process.name": {
+                    "wildcard": "jenkins*"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_anomalous_user_name_ecs.json
@@ -1,0 +1,71 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_rare_metadata_process.json
@@ -1,0 +1,66 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "destination.ip": "169.254.169.254"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_linux_rare_metadata_user.json
@@ -1,0 +1,66 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "destination.ip": "169.254.169.254"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_rare_process_by_host_linux_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/datafeed_v2_rare_process_by_host_linux_ecs.json
@@ -1,0 +1,71 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "linux",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "debian",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "redhat",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "suse",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "ubuntu",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_anomalous_network_port_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_anomalous_network_port_activity_ecs.json
@@ -1,0 +1,55 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux -  Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "network"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"destination.port\"",
+        "function": "rare",
+        "by_field_name": "destination.port"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,54 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "512mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_anomalous_user_name_ecs.json
@@ -1,0 +1,54 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process"
+  ],
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_rare_metadata_process.json
@@ -1,0 +1,36 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name",
+      "process.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux"
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/v2_linux_rare_metadata_user.json
@@ -1,0 +1,35 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux"
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_linux/ml/v2_rare_process_by_host_linux_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_linux/ml/v2_rare_process_by_host_linux_ecs.json
@@ -1,0 +1,55 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Linux - Looks for processes that are unusual to a particular Linux host. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "endpoint",
+    "linux",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare process executions on Linux",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "host.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-linux",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/logo.json
+++ b/Machine Learning/Anomaly Detection/security_windows/logo.json
@@ -1,0 +1,3 @@
+{
+  "icon": "logoSecurity"
+}

--- a/Machine Learning/Anomaly Detection/security_windows/manifest.json
+++ b/Machine Learning/Anomaly Detection/security_windows/manifest.json
@@ -1,0 +1,112 @@
+{
+  "id": "security_windows",
+  "title": "Security: Windows",
+  "description": "Detects suspicious activity using ECS Windows events. Tested with Winlogbeat and the Elastic agent.",
+  "type": "windows data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "winlogbeat-*,logs-endpoint.events.*",
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "jobs": [
+    {
+      "id": "v2_rare_process_by_host_windows_ecs",
+      "file": "v2_rare_process_by_host_windows_ecs.json"
+    },
+    {
+      "id": "v2_windows_anomalous_network_activity_ecs",
+      "file": "v2_windows_anomalous_network_activity_ecs.json"
+    },
+    {
+      "id": "v2_windows_anomalous_path_activity_ecs",
+      "file": "v2_windows_anomalous_path_activity_ecs.json"
+    },
+    {
+      "id": "v2_windows_anomalous_process_all_hosts_ecs",
+      "file": "v2_windows_anomalous_process_all_hosts_ecs.json"
+    },
+    {
+      "id": "v2_windows_anomalous_process_creation",
+      "file": "v2_windows_anomalous_process_creation.json"
+    },
+    {
+      "id": "v2_windows_anomalous_user_name_ecs",
+      "file": "v2_windows_anomalous_user_name_ecs.json"
+    },
+    {
+      "id": "v2_windows_rare_metadata_process",
+      "file": "v2_windows_rare_metadata_process.json"
+    },
+    {
+      "id": "v2_windows_rare_metadata_user",
+      "file": "v2_windows_rare_metadata_user.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-v2_rare_process_by_host_windows_ecs",
+      "file": "datafeed_v2_rare_process_by_host_windows_ecs.json",
+      "job_id": "v2_rare_process_by_host_windows_ecs"
+    },
+    {
+      "id": "datafeed-v2_windows_anomalous_network_activity_ecs",
+      "file": "datafeed_v2_windows_anomalous_network_activity_ecs.json",
+      "job_id": "v2_windows_anomalous_network_activity_ecs"
+    },
+    {
+      "id": "datafeed-v2_windows_anomalous_path_activity_ecs",
+      "file": "datafeed_v2_windows_anomalous_path_activity_ecs.json",
+      "job_id": "v2_windows_anomalous_path_activity_ecs"
+    },
+    {
+      "id": "datafeed-v2_windows_anomalous_process_all_hosts_ecs",
+      "file": "datafeed_v2_windows_anomalous_process_all_hosts_ecs.json",
+      "job_id": "v2_windows_anomalous_process_all_hosts_ecs"
+    },
+    {
+      "id": "datafeed-v2_windows_anomalous_process_creation",
+      "file": "datafeed_v2_windows_anomalous_process_creation.json",
+      "job_id": "v2_windows_anomalous_process_creation"
+    },
+    {
+      "id": "datafeed-v2_windows_anomalous_user_name_ecs",
+      "file": "datafeed_v2_windows_anomalous_user_name_ecs.json",
+      "job_id": "v2_windows_anomalous_user_name_ecs"
+    },
+    {
+      "id": "datafeed-v2_windows_rare_metadata_process",
+      "file": "datafeed_v2_windows_rare_metadata_process.json",
+      "job_id": "v2_windows_rare_metadata_process"
+    },
+    {
+      "id": "datafeed-v2_windows_rare_metadata_user",
+      "file": "datafeed_v2_windows_rare_metadata_user.json",
+      "job_id": "v2_windows_rare_metadata_user"
+    }
+  ]
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_rare_process_by_host_windows_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_rare_process_by_host_windows_ecs.json
@@ -1,0 +1,47 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_network_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_network_activity_ecs.json
@@ -1,0 +1,71 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "network"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "must_not": [
+        {
+          "bool": {
+            "should": [
+              {
+                "term": {
+                  "destination.ip": "127.0.0.1"
+                }
+              },
+              {
+                "term": {
+                  "destination.ip": "127.0.0.53"
+                }
+              },
+              {
+                "term": {
+                  "destination.ip": "::1"
+                }
+              }
+            ],
+            "minimum_should_match": 1
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_path_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_path_activity_ecs.json
@@ -1,0 +1,47 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,47 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_process_creation.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_process_creation.json
@@ -1,0 +1,47 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_anomalous_user_name_ecs.json
@@ -1,0 +1,47 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "event.category": "process"
+          }
+        },
+        {
+          "term": {
+            "event.type": "start"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "host.os.family": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "host.os.type": {
+                    "query": "windows",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_rare_metadata_process.json
@@ -1,0 +1,23 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "host.os.family": "windows"
+          }
+        },
+        {
+          "term": {
+            "destination.ip": "169.254.169.254"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/datafeed_v2_windows_rare_metadata_user.json
@@ -1,0 +1,23 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "host.os.family": "windows"
+          }
+        },
+        {
+          "term": {
+            "destination.ip": "169.254.169.254"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_rare_process_by_host_windows_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_rare_process_by_host_windows_ecs.json
@@ -1,0 +1,57 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Detects unusually rare processes on Windows hosts.",
+  "groups": [
+    "security",
+    "endpoint",
+    "event-log",
+    "sysmon",
+    "windows",
+    "winlogbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare process executions on Windows",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "host.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_network_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_network_activity_ecs.json
@@ -1,0 +1,56 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
+  "groups": [
+    "security",
+    "endpoint",
+    "sysmon",
+    "windows",
+    "winlogbeat",
+    "network"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "64mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_path_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_path_activity_ecs.json
@@ -1,0 +1,54 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "sysmon",
+    "windows",
+    "winlogbeat",
+    "process"
+  ],
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.working_directory\"",
+        "function": "rare",
+        "by_field_name": "process.working_directory"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,56 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "security",
+    "endpoint",
+    "event-log",
+    "sysmon",
+    "windows",
+    "winlogbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.executable\"",
+        "function": "rare",
+        "by_field_name": "process.executable"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_process_creation.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_process_creation.json
@@ -1,0 +1,57 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "endpoint",
+    "event-log",
+    "sysmon",
+    "windows",
+    "winlogbeat",
+    "process"
+  ],
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "Unusual process creation activity",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "process.parent.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_anomalous_user_name_ecs.json
@@ -1,0 +1,56 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "groups": [
+    "security",
+    "endpoint",
+    "event-log",
+    "sysmon",
+    "windows",
+    "winlogbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_rare_metadata_process.json
@@ -1,0 +1,38 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "security",
+    "endpoint",
+    "event-log",
+    "process",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "process.name",
+      "host.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows"
+  }
+}

--- a/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/security_windows/ml/v2_windows_rare_metadata_user.json
@@ -1,0 +1,37 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "This is a new refactored job which works on ECS compatible events across multiple indices. Security: Windows - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+  "groups": [
+    "security",
+    "endpoint",
+    "event-log",
+    "process",
+    "sysmon",
+    "windows",
+    "winlogbeat"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-security-windows"
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/logo.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/logo.json
@@ -1,0 +1,3 @@
+{
+	"icon": "logoSecurity"
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/manifest.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/manifest.json
@@ -1,0 +1,173 @@
+{
+  "id": "siem_auditbeat",
+  "title": "Security: Auditbeat",
+  "description": "Detect suspicious network activity and unusual processes in Auditbeat data.",
+  "type": "Auditbeat data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "auditbeat-*",
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"agent.type": "auditbeat"}}
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
+    }
+  },
+  "jobs": [
+    {
+      "id": "rare_process_by_host_linux_ecs",
+      "file": "rare_process_by_host_linux_ecs.json"
+    },
+    {
+      "id": "linux_anomalous_network_activity_ecs",
+      "file": "linux_anomalous_network_activity_ecs.json"
+    },
+    {
+      "id": "linux_anomalous_network_port_activity_ecs",
+      "file": "linux_anomalous_network_port_activity_ecs.json"
+    },
+    {
+      "id": "linux_anomalous_network_service",
+      "file": "linux_anomalous_network_service.json"
+    },
+    {
+      "id": "linux_anomalous_network_url_activity_ecs",
+      "file": "linux_anomalous_network_url_activity_ecs.json"
+    },
+    {
+      "id": "linux_anomalous_process_all_hosts_ecs",
+      "file": "linux_anomalous_process_all_hosts_ecs.json"
+    },
+    {
+      "id": "linux_anomalous_user_name_ecs",
+      "file": "linux_anomalous_user_name_ecs.json"
+    },
+    {
+      "id": "linux_rare_metadata_process",
+      "file": "linux_rare_metadata_process.json"
+    },
+    {
+      "id": "linux_rare_metadata_user",
+      "file": "linux_rare_metadata_user.json"
+    },
+    {
+      "id": "linux_rare_user_compiler",
+      "file": "linux_rare_user_compiler.json"
+    },
+    {
+      "id": "linux_rare_kernel_module_arguments",
+      "file": "linux_rare_kernel_module_arguments.json"
+    },
+    {
+      "id": "linux_rare_sudo_user",
+      "file": "linux_rare_sudo_user.json"
+    },
+    {
+      "id": "linux_system_user_discovery",
+      "file": "linux_system_user_discovery.json"
+    },
+    {
+      "id": "linux_system_information_discovery",
+      "file": "linux_system_information_discovery.json"
+    },
+    {
+      "id": "linux_system_process_discovery",
+      "file": "linux_system_process_discovery.json"
+    },
+    {
+      "id": "linux_network_connection_discovery",
+      "file": "linux_network_connection_discovery.json"
+    },
+    {
+      "id": "linux_network_configuration_discovery",
+      "file": "linux_network_configuration_discovery.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-rare_process_by_host_linux_ecs",
+      "file": "datafeed_rare_process_by_host_linux_ecs.json",
+      "job_id": "rare_process_by_host_linux_ecs"
+    },
+    {
+      "id": "datafeed-linux_anomalous_network_activity_ecs",
+      "file": "datafeed_linux_anomalous_network_activity_ecs.json",
+      "job_id": "linux_anomalous_network_activity_ecs"
+    },
+    {
+      "id": "datafeed-linux_anomalous_network_port_activity_ecs",
+      "file": "datafeed_linux_anomalous_network_port_activity_ecs.json",
+      "job_id": "linux_anomalous_network_port_activity_ecs"
+    },
+    {
+      "id": "datafeed-linux_anomalous_network_service",
+      "file": "datafeed_linux_anomalous_network_service.json",
+      "job_id": "linux_anomalous_network_service"
+    },
+    {
+      "id": "datafeed-linux_anomalous_network_url_activity_ecs",
+      "file": "datafeed_linux_anomalous_network_url_activity_ecs.json",
+      "job_id": "linux_anomalous_network_url_activity_ecs"
+    },
+    {
+      "id": "datafeed-linux_anomalous_process_all_hosts_ecs",
+      "file": "datafeed_linux_anomalous_process_all_hosts_ecs.json",
+      "job_id": "linux_anomalous_process_all_hosts_ecs"
+    },
+    {
+      "id": "datafeed-linux_anomalous_user_name_ecs",
+      "file": "datafeed_linux_anomalous_user_name_ecs.json",
+      "job_id": "linux_anomalous_user_name_ecs"
+    },
+    {
+      "id": "datafeed-linux_rare_metadata_process",
+      "file": "datafeed_linux_rare_metadata_process.json",
+      "job_id": "linux_rare_metadata_process"
+    },
+    {
+      "id": "datafeed-linux_rare_metadata_user",
+      "file": "datafeed_linux_rare_metadata_user.json",
+      "job_id": "linux_rare_metadata_user"
+    },
+    {
+      "id": "datafeed-linux_rare_user_compiler",
+      "file": "datafeed_linux_rare_user_compiler.json",
+      "job_id": "linux_rare_user_compiler"
+    },
+    {
+      "id": "datafeed-linux_rare_kernel_module_arguments",
+      "file": "datafeed_linux_rare_kernel_module_arguments.json",
+      "job_id": "linux_rare_kernel_module_arguments"
+    },
+    {
+      "id": "datafeed-linux_rare_sudo_user",
+      "file": "datafeed_linux_rare_sudo_user.json",
+      "job_id": "linux_rare_sudo_user"
+    },
+    {
+      "id": "datafeed-linux_system_information_discovery",
+      "file": "datafeed_linux_system_information_discovery.json",
+      "job_id": "linux_system_information_discovery"
+    },
+    {
+      "id": "datafeed-linux_system_process_discovery",
+      "file": "datafeed_linux_system_process_discovery.json",
+      "job_id": "linux_system_process_discovery"
+    },
+    {
+      "id": "datafeed-linux_system_user_discovery",
+      "file": "datafeed_linux_system_user_discovery.json",
+      "job_id": "linux_system_user_discovery"
+    },
+    {
+      "id": "datafeed-linux_network_configuration_discovery",
+      "file": "datafeed_linux_network_configuration_discovery.json",
+      "job_id": "linux_network_configuration_discovery"
+    },
+    {
+      "id": "datafeed-linux_network_connection_discovery",
+      "file": "datafeed_linux_network_connection_discovery.json",
+      "job_id": "linux_network_connection_discovery"
+    }
+  ]
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_activity_ecs.json
@@ -1,0 +1,27 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+            "bool": {
+              "filter": [
+                {"term": {"event.action": "connected-to"}},
+                {"term": {"agent.type": "auditbeat"}}
+              ],
+              "must_not": [
+                {
+                  "bool": {
+                    "should": [
+                      {"term": {"destination.ip": "127.0.0.1"}},
+                      {"term": {"destination.ip": "127.0.0.53"}},
+                      {"term": {"destination.ip": "::1"}}
+                    ],
+                    "minimum_should_match": 1
+                  }
+                }
+              ]
+            }
+        }
+    }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_port_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_port_activity_ecs.json
@@ -1,0 +1,28 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"event.action": "connected-to"}},
+          {"term": {"agent.type": "auditbeat"}}
+        ],
+        "must_not": [
+          {
+            "bool": {
+              "should": [
+                {"term": {"destination.ip":"::1"}},
+                {"term": {"destination.ip":"127.0.0.1"}},
+                {"term": {"destination.ip":"::"}},
+                {"term": {"user.name_map.uid":"jenkins"}}
+              ],
+              "minimum_should_match": 1
+            }
+          }
+        ]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_service.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_service.json
@@ -1,0 +1,27 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.action": "bound-socket"}},
+            {"term": {"agent.type": "auditbeat"}}
+          ],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {"term": {"process.name": "dnsmasq"}},
+                  {"term": {"process.name": "docker-proxy"}},
+                  {"term": {"process.name": "rpcinfo"}}
+                ],
+                "minimum_should_match": 1
+              }
+            }
+        ]
+        }
+      }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_url_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_network_url_activity_ecs.json
@@ -1,0 +1,28 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool":{
+          "filter": [
+            {"exists": {"field": "destination.ip"}},
+            {"terms": {"process.name": ["curl", "wget"]}},
+            {"term": {"agent.type": "auditbeat"}}
+          ],
+          "must_not":[
+            {
+              "bool":{
+                "should":[
+                    {"term":{"destination.ip": "::1"}},
+                    {"term":{"destination.ip": "127.0.0.1"}},
+                    {"term":{"destination.ip":"169.254.169.254"}}
+                  ],
+                  "minimum_should_match": 1
+                }
+              }
+            ]
+        }
+      }
+    }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,28 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"terms": {"event.action": ["process_started", "executed"]}},
+            {"term": {"agent.type": "auditbeat"}}
+          ],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {"term": {"user.name": "jenkins-worker"}},
+                  {"term": {"user.name": "jenkins-user"}},
+                  {"term": {"user.name": "jenkins"}},
+                  {"wildcard": {"process.name": {"wildcard": "jenkins*"}}}
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_anomalous_user_name_ecs.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "filter": [
+              {"terms": {"event.action": ["process_started", "executed"]}},
+              {"term": {"agent.type":"auditbeat"}}
+            ]
+          }
+      }
+    }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_network_configuration_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_network_configuration_discovery.json
@@ -1,0 +1,26 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {"term": {"process.name": "arp"}},
+                    {"term": {"process.name": "echo"}},
+                    {"term": {"process.name": "ethtool"}},
+                    {"term": {"process.name": "ifconfig"}},
+                    {"term": {"process.name": "ip"}},
+                    {"term": {"process.name": "iptables"}},
+                    {"term": {"process.name": "ufw"}}
+                  ]
+                }
+              }
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_network_connection_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_network_connection_discovery.json
@@ -1,0 +1,23 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {"term": {"process.name": "netstat"}},
+                    {"term": {"process.name": "ss"}},
+                    {"term": {"process.name": "route"}},
+                    {"term": {"process.name": "showmount"}}
+                  ]
+                }
+              }
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_kernel_module_arguments.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_kernel_module_arguments.json
@@ -1,0 +1,22 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "filter": [{"exists": {"field": "process.title"}}],
+            "must": [
+                {"bool": {
+                    "should": [
+                    {"term": {"process.name": "insmod"}},
+                    {"term": {"process.name": "kmod"}},
+                    {"term": {"process.name": "modprobe"}},
+                    {"term": {"process.name": "rmod"}}
+                    ]
+                }}
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_metadata_process.json
@@ -1,0 +1,12 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [{"term": {"destination.ip": "169.254.169.254"}}]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_metadata_user.json
@@ -1,0 +1,12 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [{"term": {"destination.ip": "169.254.169.254"}}]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_sudo_user.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_sudo_user.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": {"event.action": "executed"}},
+          {"term": {"process.name": "sudo"}}
+        ]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_user_compiler.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_rare_user_compiler.json
@@ -1,0 +1,22 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "filter": [{"term": {"event.action": "executed"}}],
+            "must": [
+              {"bool": {
+                  "should": [
+                    {"term": {"process.name": "compile"}},
+                    {"term": {"process.name": "gcc"}},
+                    {"term": {"process.name": "make"}},
+                    {"term": {"process.name": "yasm"}}
+                  ]
+                }}
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_system_information_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_system_information_discovery.json
@@ -1,0 +1,31 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {"term": {"process.name": "cat"}},
+                    {"term": {"process.name": "grep"}},
+                    {"term": {"process.name": "head"}},
+                    {"term": {"process.name": "hostname"}},
+                    {"term": {"process.name": "less"}},
+                    {"term": {"process.name": "ls"}},
+                    {"term": {"process.name": "lsmod"}},
+                    {"term": {"process.name": "more"}},
+                    {"term": {"process.name": "strings"}},
+                    {"term": {"process.name": "tail"}},
+                    {"term": {"process.name": "uptime"}},
+                    {"term": {"process.name": "uname"}}
+                  ]
+                }
+              }
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_system_process_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_system_process_discovery.json
@@ -1,0 +1,21 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {"term": {"process.name": "ps"}},
+                    {"term": {"process.name": "top"}}
+                  ]
+                }
+              }
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_system_user_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_linux_system_user_discovery.json
@@ -1,0 +1,23 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+            "must": [
+              {
+                "bool": {
+                  "should": [
+                    {"term": {"process.name": "users"}},
+                    {"term": {"process.name": "w"}},
+                    {"term": {"process.name": "who"}},
+                    {"term": {"process.name": "whoami"}}
+                  ]
+                }
+              }
+            ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_rare_process_by_host_linux_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/datafeed_rare_process_by_host_linux_ecs.json
@@ -1,0 +1,16 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {"terms": {"event.action": ["process_started", "executed"]}},
+          { "term": { "agent.type": "auditbeat" } }
+
+        ]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_activity_ecs.json
@@ -1,0 +1,53 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Auditbeat - Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "64mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_port_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_port_activity_ecs.json
@@ -1,0 +1,53 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Auditbeat - Looks for unusual destination port activity that could indicate command-and-control, persistence mechanism, or data exfiltration activity.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "network"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"destination.port\"",
+        "function": "rare",
+        "by_field_name": "destination.port"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_service.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_service.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "auditbeat",
+    "network"
+  ],
+  "description": "Security: Auditbeat - Looks for unusual listening ports that could indicate execution of unauthorized services, backdoors, or persistence mechanisms.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"auditd.data.socket.port\"",
+        "function": "rare",
+        "by_field_name": "auditd.data.socket.port"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "128mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_url_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_network_url_activity_ecs.json
@@ -1,0 +1,40 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "auditbeat",
+    "network"
+  ],
+  "description": "Security: Auditbeat - Looks for an unusual web URL request from a Linux instance. Curl and wget web request activity is very common but unusual web requests from a Linux server can sometimes be malware delivery or execution.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.title\"",
+        "function": "rare",
+        "by_field_name": "process.title"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "destination.ip",
+      "destination.port"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Auditbeat - Looks for processes that are unusual to all Linux hosts. Such unusual processes may indicate unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "512mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_anomalous_user_name_ecs.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "auditbeat",
+    "process"
+  ],
+  "description": "Security: Auditbeat - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "32mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_network_configuration_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_network_configuration_discovery.json
@@ -1,0 +1,53 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for commands related to system network configuration discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network configuration discovery in order to increase their understanding of connected networks and hosts. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "64mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_network_connection_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_network_connection_discovery.json
@@ -1,0 +1,53 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for commands related to system network connection discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used by a threat actor to engage in system network connection discovery in order to increase their understanding of connected services and systems. This information may be used to shape follow-up behaviors such as lateral movement or additional discovery.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "64mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_kernel_module_arguments.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_kernel_module_arguments.json
@@ -1,0 +1,45 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for unusual kernel modules which are often used for stealth.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"process.title\"",
+          "function": "rare",
+          "by_field_name": "process.title"
+        }
+      ],
+      "influencers": [
+        "process.title",
+        "process.working_directory",
+        "host.name",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "32mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_metadata_process.json
@@ -1,0 +1,52 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"process.name\"",
+          "function": "rare",
+          "by_field_name": "process.name"
+        }
+      ],
+      "influencers": [
+        "host.name",
+        "user.name",
+        "process.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "32mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_metadata_user.json
@@ -1,0 +1,43 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "host.name",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "32mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_sudo_user.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_sudo_user.json
@@ -1,0 +1,53 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for sudo activity from an unusual user context.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "32mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_user_compiler.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_rare_user_compiler.json
@@ -1,0 +1,45 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for compiler activity by a user context which does not normally run compilers. This can be ad-hoc software changes or unauthorized software deployment. This can also be due to local privilege elevation via locally run exploits or malware activity.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.title",
+        "host.name",
+        "process.working_directory",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "256mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_system_information_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_system_information_discovery.json
@@ -1,0 +1,53 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for commands related to system information discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system information discovery in order to gather detailed information about system configuration and software versions. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "16mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_system_process_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_system_process_discovery.json
@@ -1,0 +1,53 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for commands related to system process discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system process discovery in order to increase their understanding of software applications running on a target host or network. This may be a precursor to selection of a persistence mechanism or a method of privilege elevation.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "16mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_system_user_discovery.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/linux_system_user_discovery.json
@@ -1,0 +1,53 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Auditbeat - Looks for commands related to system user or owner discovery from an unusual user context. This can be due to uncommon troubleshooting activity or due to a compromised account. A compromised account may be used to engage in system owner or user discovery in order to identify currently active or primary users of a system. This may be a precursor to additional discovery, credential dumping or privilege elevation activity.",
+    "groups": [
+      "security",
+      "auditbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "process.args",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "16mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-auditbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_auditbeat/ml/rare_process_by_host_linux_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat/ml/rare_process_by_host_linux_ecs.json
@@ -1,0 +1,53 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Auditbeat - Detect unusually rare processes on Linux",
+  "groups": [
+    "security",
+    "auditbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare process executions on Linux",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "host.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat_auth/logo.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat_auth/logo.json
@@ -1,0 +1,3 @@
+{
+	"icon": "logoSecurity"
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat_auth/manifest.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat_auth/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "siem_auditbeat_auth",
+  "title": "Security: Auditbeat Authentication",
+  "description": "Detect suspicious authentication events in Auditbeat data.",
+  "type": "Auditbeat data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "auditbeat-*",
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"event.category": "authentication"}},
+        {"term": {"agent.type": "auditbeat"}}
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
+    }
+  },
+  "jobs": [
+    {
+      "id": "suspicious_login_activity_ecs",
+      "file": "suspicious_login_activity_ecs.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-suspicious_login_activity_ecs",
+      "file": "datafeed_suspicious_login_activity_ecs.json",
+      "job_id": "suspicious_login_activity_ecs"
+    }
+  ]
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat_auth/ml/datafeed_suspicious_login_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat_auth/ml/datafeed_suspicious_login_activity_ecs.json
@@ -1,0 +1,15 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": { "event.category": "authentication" }},
+        {"term": { "agent.type": "auditbeat" }}
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_auditbeat_auth/ml/suspicious_login_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_auditbeat_auth/ml/suspicious_login_activity_ecs.json
@@ -1,0 +1,41 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Auditbeat - Detect unusually high number of authentication attempts.",
+  "groups": [
+    "security",
+    "auditbeat",
+    "authentication"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "high number of authentication attempts",
+        "function": "high_non_zero_count",
+        "partition_field_name": "host.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name",
+      "source.ip"
+    ],
+    "model_prune_window": "30d"
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-auditbeat",
+    "custom_urls": [
+      {
+        "url_name": "IP Address Details",
+        "url_value": "security/network/ml-network/ip/$source.ip$?_g=()&query=!n&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/logo.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/logo.json
@@ -1,0 +1,3 @@
+{
+	"icon": "logoSecurity"
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/manifest.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/manifest.json
@@ -1,0 +1,119 @@
+{
+  "id": "siem_winlogbeat",
+  "title": "Security: Winlogbeat",
+  "description": "Detect unusual processes and network activity in Winlogbeat data.",
+  "type": "Winlogbeat data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "winlogbeat-*",
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"agent.type": "winlogbeat"}}
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
+    }
+  },
+  "jobs": [
+    {
+      "id": "rare_process_by_host_windows_ecs",
+      "file": "rare_process_by_host_windows_ecs.json"
+    },
+    {
+      "id": "windows_anomalous_network_activity_ecs",
+      "file": "windows_anomalous_network_activity_ecs.json"
+    },
+    {
+      "id": "windows_anomalous_path_activity_ecs",
+      "file": "windows_anomalous_path_activity_ecs.json"
+    },
+    {
+      "id": "windows_anomalous_process_all_hosts_ecs",
+      "file": "windows_anomalous_process_all_hosts_ecs.json"
+    },
+    {
+      "id": "windows_anomalous_process_creation",
+      "file": "windows_anomalous_process_creation.json"
+    },
+    {
+      "id": "windows_anomalous_script",
+      "file": "windows_anomalous_script.json"
+    },
+    {
+      "id": "windows_anomalous_service",
+      "file": "windows_anomalous_service.json"
+    },
+    {
+      "id": "windows_anomalous_user_name_ecs",
+      "file": "windows_anomalous_user_name_ecs.json"
+    },
+    {
+      "id": "windows_rare_user_runas_event",
+      "file": "windows_rare_user_runas_event.json"
+    },
+    {
+      "id": "windows_rare_metadata_process",
+      "file": "windows_rare_metadata_process.json"
+    },
+    {
+      "id": "windows_rare_metadata_user",
+      "file": "windows_rare_metadata_user.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-rare_process_by_host_windows_ecs",
+      "file": "datafeed_rare_process_by_host_windows_ecs.json",
+      "job_id": "rare_process_by_host_windows_ecs"
+    },
+    {
+      "id": "datafeed-windows_anomalous_network_activity_ecs",
+      "file": "datafeed_windows_anomalous_network_activity_ecs.json",
+      "job_id": "windows_anomalous_network_activity_ecs"
+    },
+    {
+      "id": "datafeed-windows_anomalous_path_activity_ecs",
+      "file": "datafeed_windows_anomalous_path_activity_ecs.json",
+      "job_id": "windows_anomalous_path_activity_ecs"
+    },
+    {
+      "id": "datafeed-windows_anomalous_process_all_hosts_ecs",
+      "file": "datafeed_windows_anomalous_process_all_hosts_ecs.json",
+      "job_id": "windows_anomalous_process_all_hosts_ecs"
+    },
+    {
+      "id": "datafeed-windows_anomalous_process_creation",
+      "file": "datafeed_windows_anomalous_process_creation.json",
+      "job_id": "windows_anomalous_process_creation"
+    },
+    {
+      "id": "datafeed-windows_anomalous_script",
+      "file": "datafeed_windows_anomalous_script.json",
+      "job_id": "windows_anomalous_script"
+    },
+    {
+      "id": "datafeed-windows_anomalous_service",
+      "file": "datafeed_windows_anomalous_service.json",
+      "job_id": "windows_anomalous_service"
+    },
+    {
+      "id": "datafeed-windows_anomalous_user_name_ecs",
+      "file": "datafeed_windows_anomalous_user_name_ecs.json",
+      "job_id": "windows_anomalous_user_name_ecs"
+    },
+    {
+      "id": "datafeed-windows_rare_user_runas_event",
+      "file": "datafeed_windows_rare_user_runas_event.json",
+      "job_id": "windows_rare_user_runas_event"
+    },
+    {
+      "id": "datafeed-windows_rare_metadata_process",
+      "file": "datafeed_windows_rare_metadata_process.json",
+      "job_id": "windows_rare_metadata_process"
+    },
+    {
+      "id": "datafeed-windows_rare_metadata_user",
+      "file": "datafeed_windows_rare_metadata_user.json",
+      "job_id": "windows_rare_metadata_user"
+    }
+  ]
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_rare_process_by_host_windows_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_rare_process_by_host_windows_ecs.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [
+          {"term": { "event.action": "Process Create (rule: ProcessCreate)" }},
+          {"term": {"agent.type": "winlogbeat"}}
+        ]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_network_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_network_activity_ecs.json
@@ -1,0 +1,27 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.action": "Network connection detected (rule: NetworkConnect)"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ],
+          "must_not": [
+            {
+              "bool": {
+                "should": [
+                  {"term": {"destination.ip": "127.0.0.1"}},
+                  {"term": {"destination.ip": "127.0.0.53"}},
+                  {"term": {"destination.ip": "::1"}}
+                ],
+                "minimum_should_match": 1
+              }
+            }
+          ]
+        }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_path_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_path_activity_ecs.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.action": "Process Create (rule: ProcessCreate)"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+        }
+      }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.action": "Process Create (rule: ProcessCreate)"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+        }
+      }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_process_creation.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_process_creation.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.action": "Process Create (rule: ProcessCreate)"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+      }
+    }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_script.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_script.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"winlog.channel": "Microsoft-Windows-PowerShell/Operational"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+        }
+      }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_service.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_service.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.code": "7045"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+        }
+      }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_anomalous_user_name_ecs.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.action": "Process Create (rule: ProcessCreate)"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+        }
+      }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_rare_metadata_process.json
@@ -1,0 +1,12 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [{"term": {"destination.ip": "169.254.169.254"}}]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_rare_metadata_user.json
@@ -1,0 +1,12 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+      "bool": {
+        "filter": [{"term": {"destination.ip": "169.254.169.254"}}]
+      }
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_rare_user_runas_event.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/datafeed_windows_rare_user_runas_event.json
@@ -1,0 +1,15 @@
+{
+    "job_id": "JOB_ID",
+    "indices": [
+      "INDEX_PATTERN_NAME"
+    ],
+    "max_empty_searches": 10,
+    "query": {
+        "bool": {
+          "filter": [
+            {"term": {"event.code": "4648"}},
+            {"term": {"agent.type": "winlogbeat"}}
+          ]
+        }
+      }
+    }

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/rare_process_by_host_windows_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/rare_process_by_host_windows_ecs.json
@@ -1,0 +1,53 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat - Detect unusually rare processes on Windows.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare process executions on Windows",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "host.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_network_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_network_activity_ecs.json
@@ -1,0 +1,53 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat - Looks for unusual processes using the network which could indicate command-and-control, lateral movement, persistence, or data exfiltration activity.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "network"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.name\"",
+        "function": "rare",
+        "by_field_name": "process.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name",
+      "destination.ip"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "64mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_path_activity_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_path_activity_ecs.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "process"
+  ],
+  "description": "Security: Winlogbeat - Looks for activity in unusual paths that may indicate execution of malware or persistence mechanisms. Windows payloads often execute from user profile paths.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.working_directory\"",
+        "function": "rare",
+        "by_field_name": "process.working_directory"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_process_all_hosts_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_process_all_hosts_ecs.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat - Looks for processes that are unusual to all Windows hosts. Such unusual processes may indicate execution of unauthorized services, malware, or persistence mechanisms.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"process.executable\"",
+        "function": "rare",
+        "by_field_name": "process.executable"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_process_creation.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_process_creation.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "process"
+  ],
+  "description": "Security: Winlogbeat - Looks for unusual process relationships which may indicate execution of malware or persistence mechanisms.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "Unusual process creation activity",
+        "function": "rare",
+        "by_field_name": "process.name",
+        "partition_field_name": "process.parent.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_script.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_script.json
@@ -1,0 +1,45 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat - Looks for unusual powershell scripts that may indicate execution of malware, or persistence mechanisms.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "powershell"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "high_info_content(\"winlog.event_data.ScriptBlockText\")",
+        "function": "high_info_content",
+        "field_name": "winlog.event_data.ScriptBlockText"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "user.name",
+      "winlog.event_data.Path"
+    ],
+    "model_prune_window": "30d"
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_service.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_service.json
@@ -1,0 +1,39 @@
+{
+  "job_type": "anomaly_detector",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "system"
+  ],
+  "description": "Security: Winlogbeat - Looks for rare and unusual Windows services which may indicate execution of unauthorized services, malware, or persistence mechanisms.",
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"winlog.event_data.ServiceName\"",
+        "function": "rare",
+        "by_field_name": "winlog.event_data.ServiceName"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "winlog.event_data.ServiceName"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_user_name_ecs.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_anomalous_user_name_ecs.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat - Rare and unusual users that are not normally active may indicate unauthorized changes or activity by an unauthorized user which may be credentialed access or lateral movement.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "process"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "256mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_rare_metadata_process.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_rare_metadata_process.json
@@ -1,0 +1,52 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Winlogbeat - Looks for anomalous access to the metadata service by an unusual process. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+    "groups": [
+      "security",
+      "winlogbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"process.name\"",
+          "function": "rare",
+          "by_field_name": "process.name"
+        }
+      ],
+      "influencers": [
+        "process.name",
+        "host.name",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "64mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-winlogbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by process name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by process name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_rare_metadata_user.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_rare_metadata_user.json
@@ -1,0 +1,43 @@
+{
+    "job_type": "anomaly_detector",
+    "description": "Security: Winlogbeat - Looks for anomalous access to the metadata service by an unusual user. The metadata service may be targeted in order to harvest credentials or user data scripts containing secrets.",
+    "groups": [
+      "security",
+      "winlogbeat",
+      "process"
+    ],
+    "analysis_config": {
+      "bucket_span": "15m",
+      "detectors": [
+        {
+          "detector_description": "rare by \"user.name\"",
+          "function": "rare",
+          "by_field_name": "user.name"
+        }
+      ],
+      "influencers": [
+        "host.name",
+        "user.name"
+      ]
+    },
+    "allow_lazy_open": true,
+    "analysis_limits": {
+      "model_memory_limit": "32mb"
+    },
+    "data_description": {
+      "time_field": "@timestamp"
+    },
+    "custom_settings": {
+      "created_by": "ml-module-siem-winlogbeat",
+      "custom_urls": [
+        {
+          "url_name": "Host Details by user name",
+          "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        },
+        {
+          "url_name": "Hosts Overview by user name",
+          "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+        }
+      ]
+    }
+  }

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_rare_user_runas_event.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat/ml/windows_rare_user_runas_event.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat - Unusual user context switches can be due to privilege escalation.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "authentication"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "128mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/logo.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/logo.json
@@ -1,0 +1,3 @@
+{
+	"icon": "logoSecurity"
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/manifest.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/manifest.json
@@ -1,0 +1,30 @@
+{
+  "id": "siem_winlogbeat_auth",
+  "title": "Security: Winlogbeat Authentication",
+  "description": "Detect suspicious authentication events in Winlogbeat data.",
+  "type": "Winlogbeat data",
+  "logoFile": "logo.json",
+  "defaultIndexPattern": "winlogbeat-*",
+  "query": {
+    "bool": {
+      "filter": [
+        {"term": {"agent.type": "winlogbeat"}},
+        {"term": {"event.category": "authentication"}}
+      ],
+      "must_not": { "terms": { "_tier": [ "data_frozen", "data_cold" ] } }
+    }
+  },
+  "jobs": [
+    {
+      "id": "windows_rare_user_type10_remote_login",
+      "file": "windows_rare_user_type10_remote_login.json"
+    }
+  ],
+  "datafeeds": [
+    {
+      "id": "datafeed-windows_rare_user_type10_remote_login",
+      "file": "datafeed_windows_rare_user_type10_remote_login.json",
+      "job_id": "windows_rare_user_type10_remote_login"
+    }
+  ]
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/ml/datafeed_windows_rare_user_type10_remote_login.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/ml/datafeed_windows_rare_user_type10_remote_login.json
@@ -1,0 +1,42 @@
+{
+  "job_id": "JOB_ID",
+  "indices": [
+    "INDEX_PATTERN_NAME"
+  ],
+  "max_empty_searches": 10,
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "term": {
+            "winlog.event_data.LogonType": "10"
+          }
+        }
+      ],
+      "must": [
+        {
+          "bool": {
+            "should": [
+              {
+                "match": {
+                  "event.type": {
+                    "query": "authentication_success",
+                    "operator": "OR"
+                  }
+                }
+              },
+              {
+                "match": {
+                  "event.action": {
+                    "query": "logged-in",
+                    "operator": "OR"
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  }
+}

--- a/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/ml/windows_rare_user_type10_remote_login.json
+++ b/Machine Learning/Anomaly Detection/siem_winlogbeat_auth/ml/windows_rare_user_type10_remote_login.json
@@ -1,0 +1,52 @@
+{
+  "job_type": "anomaly_detector",
+  "description": "Security: Winlogbeat Auth - Unusual RDP (remote desktop protocol) user logins can indicate account takeover or credentialed access.",
+  "groups": [
+    "security",
+    "winlogbeat",
+    "authentication"
+  ],
+  "analysis_config": {
+    "bucket_span": "15m",
+    "detectors": [
+      {
+        "detector_description": "rare by \"user.name\"",
+        "function": "rare",
+        "by_field_name": "user.name"
+      }
+    ],
+    "influencers": [
+      "host.name",
+      "process.name",
+      "user.name"
+    ]
+  },
+  "allow_lazy_open": true,
+  "analysis_limits": {
+    "model_memory_limit": "128mb"
+  },
+  "data_description": {
+    "time_field": "@timestamp"
+  },
+  "custom_settings": {
+    "created_by": "ml-module-siem-winlogbeat-auth",
+    "custom_urls": [
+      {
+        "url_name": "Host Details by process name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Host Details by user name",
+        "url_value": "security/hosts/ml-hosts/$host.name$?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by process name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'process.name%20:%20%22$process.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      },
+      {
+        "url_name": "Hosts Overview by user name",
+        "url_value": "security/hosts/ml-hosts?_g=()&query=(query:'user.name%20:%20%22$user.name$%22',language:kuery)&timerange=(global:(linkTo:!(timeline),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')),timeline:(linkTo:!(global),timerange:(from:'$earliest$',kind:absolute,to:'$latest$')))"
+      }
+    ]
+  }
+}


### PR DESCRIPTION

Archiving and sharing versions 1 and 2 of the anomaly detection modules and jobs for Linux and Windows. These were deprecated in 8.3 and are only needed in cases where older fleets and / or datasets are being processed. 